### PR TITLE
Adjust the title of an isEmail test

### DIFF
--- a/valiktor-core/src/test/kotlin/org/valiktor/functions/StringFunctionsTest.kt
+++ b/valiktor-core/src/test/kotlin/org/valiktor/functions/StringFunctionsTest.kt
@@ -1464,7 +1464,7 @@ class StringFunctionsTest {
     }
 
     @Test
-    fun `isEmail with blank value should be invalid`() {
+    fun `isEmail with invalid value should be invalid`() {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(email = "test.test")) {
                 validate(Employee::email).isEmail()


### PR DESCRIPTION
## Proposed Changes

  - Adjust the title of a test related to 'isEmail' constraint, so that it correctly reflects the test's behavior.