### PR TITLE
Implemented a generic approach for the addition of new validation types.

### DIFF
--- a/valiktor-core/src/main/kotlin/org/valiktor/Validator.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/Validator.kt
@@ -135,8 +135,10 @@ open class Validator<E>(private val obj: E) {
          * @param isValid specifies the validation function
          * @return the ValidatedType validator
          */
-        fun validate(constraint: (ValidatedType?) -> Constraint,
-                     isValid: (ValidatedType?) -> Boolean): ReceiverValidator<ValidatedClass, ValidatedType> {
+        fun validate(
+            constraint: (ValidatedType?) -> Constraint,
+            isValid: (ValidatedType?) -> Boolean
+        ): ReceiverValidator<ValidatedClass, ValidatedType> {
             if (!isValid(value())) {
                 addConstraintViolation(constraint)
             }
@@ -164,8 +166,10 @@ open class Validator<E>(private val obj: E) {
          * @param isValid specifies the validation function
          * @return the ValidatedType validator
          */
-        suspend fun coValidate(constraint: (ValidatedType?) -> Constraint,
-                               isValid: suspend (ValidatedType?) -> Boolean): ReceiverValidator<ValidatedClass, ValidatedType> {
+        suspend fun coValidate(
+            constraint: (ValidatedType?) -> Constraint,
+            isValid: suspend (ValidatedType?) -> Boolean
+        ): ReceiverValidator<ValidatedClass, ValidatedType> {
             if (!isValid(value())) {
                 addConstraintViolation(constraint)
             }
@@ -232,7 +236,7 @@ open class Validator<E>(private val obj: E) {
      * @see KProperty1
      * @since 0.1.0
      */
-    open inner class Property<T>(val obj: E, val property: KProperty1<E, T?>): ReceiverValidator<E, T>() {
+    open inner class Property<T>(val obj: E, val property: KProperty1<E, T?>) : ReceiverValidator<E, T>() {
 
         override fun name(): String = this.property.name
 

--- a/valiktor-core/src/main/kotlin/org/valiktor/Validator.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/Validator.kt
@@ -148,7 +148,7 @@ open class Validator<E>(private val obj: E) {
          * @return the ValidatedType validator
          */
         fun validate(constraint: Constraint, isValid: (ValidatedType?) -> Boolean): ReceiverValidator<ValidatedClass, ValidatedType> =
-                validate({ constraint }, isValid)
+            validate({ constraint }, isValid)
 
         /**
          * Validates the ValidatedType by passing the constraint and the suspending validation function
@@ -172,7 +172,7 @@ open class Validator<E>(private val obj: E) {
          * @return the ValidatedType validator
          */
         suspend fun coValidate(constraint: Constraint, isValid: suspend (ValidatedType?) -> Boolean): ReceiverValidator<ValidatedClass, ValidatedType> =
-                coValidate({ constraint }, isValid)
+            coValidate({ constraint }, isValid)
 
         /**
          * Adds the constraint violations to property

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/AnyFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/AnyFunctions.kt
@@ -31,15 +31,15 @@ import org.valiktor.constraints.Valid
  *
  * @param block specifies the function DSL
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-inline fun <E, T> Validator<E>.Property<T?>.validate(block: Validator<T>.(T) -> Unit): Validator<E>.Property<T?> {
-    val value = this.property.get(this.obj)
+inline fun <E, T> Validator<E>.ReceiverValidator<E, T?>.validate(block: Validator<T>.(T) -> Unit): Validator<E>.ReceiverValidator<E, T?> {
+    val value = value()
     if (value != null) {
         this.addConstraintViolations(
             Validator(value).apply { block(value) }.constraintViolations.map {
                 DefaultConstraintViolation(
-                    property = "${this.property.name}.${it.property}",
+                    property = "${this.name()}.${it.property}",
                     value = it.value,
                     constraint = it.constraint
                 )
@@ -53,18 +53,18 @@ inline fun <E, T> Validator<E>.Property<T?>.validate(block: Validator<T>.(T) -> 
  * Validates if the property value is null
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isNull(): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isNull(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(Null) { it == null }
 
 /**
  * Validates if the property value is not null
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isNotNull(): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isNotNull(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(NotNull) { it != null }
 
 /**
@@ -72,9 +72,9 @@ fun <E, T> Validator<E>.Property<T?>.isNotNull(): Validator<E>.Property<T?> =
  *
  * @param value specifies the value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isEqualTo(value: T): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isEqualTo(value: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(Equals(value)) { it == null || it == value }
 
 /**
@@ -82,9 +82,9 @@ fun <E, T> Validator<E>.Property<T?>.isEqualTo(value: T): Validator<E>.Property<
  *
  * @param value specifies the value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isNotEqualTo(value: T): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isNotEqualTo(value: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(NotEquals(value)) { it == null || it != value }
 
 /**
@@ -92,9 +92,9 @@ fun <E, T> Validator<E>.Property<T?>.isNotEqualTo(value: T): Validator<E>.Proper
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isIn(vararg values: T): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isIn(vararg values: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(In(values.toSet())) { it == null || values.contains(it) }
 
 /**
@@ -102,9 +102,9 @@ fun <E, T> Validator<E>.Property<T?>.isIn(vararg values: T): Validator<E>.Proper
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isIn(values: Iterable<T>): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isIn(values: Iterable<T>): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(In(values)) { it == null || values.contains(it) }
 
 /**
@@ -112,9 +112,9 @@ fun <E, T> Validator<E>.Property<T?>.isIn(values: Iterable<T>): Validator<E>.Pro
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isNotIn(vararg values: T): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isNotIn(vararg values: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(NotIn(values.toSet())) { it == null || !values.contains(it) }
 
 /**
@@ -122,9 +122,9 @@ fun <E, T> Validator<E>.Property<T?>.isNotIn(vararg values: T): Validator<E>.Pro
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isNotIn(values: Iterable<T>): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isNotIn(values: Iterable<T>): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(NotIn(values)) { it == null || !values.contains(it) }
 
 /**
@@ -132,9 +132,9 @@ fun <E, T> Validator<E>.Property<T?>.isNotIn(values: Iterable<T>): Validator<E>.
  *
  * @param validator specifies the validation function
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<T?>.isValid(validator: (T) -> Boolean): Validator<E>.Property<T?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isValid(validator: (T) -> Boolean): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(Valid) { it == null || validator(it) }
 
 /**
@@ -142,7 +142,7 @@ fun <E, T> Validator<E>.Property<T?>.isValid(validator: (T) -> Boolean): Validat
  *
  * @param validator specifies the validation function
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-suspend fun <E, T> Validator<E>.Property<T?>.isCoValid(validator: suspend (T) -> Boolean): Validator<E>.Property<T?> =
+suspend fun <E, T> Validator<E>.ReceiverValidator<E, T?>.isCoValid(validator: suspend (T) -> Boolean): Validator<E>.ReceiverValidator<E, T?> =
     this.coValidate(Valid) { it == null || validator(it) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/ArrayFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/ArrayFunctions.kt
@@ -37,17 +37,17 @@ import org.valiktor.constraints.Size
  *
  * @param block specifies the function DSL
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("validateForEachArray")
-inline fun <E, T> Validator<E>.Property<Array<T>?>.validateForEach(
+inline fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.validateForEach(
     block: Validator<T>.(T) -> Unit
-): Validator<E>.Property<Array<T>?> {
-    this.property.get(this.obj)?.forEachIndexed { index, value ->
+): Validator<E>.ReceiverValidator<E, Array<T>?> {
+    this.value()?.forEachIndexed { index, value ->
         this.addConstraintViolations(
             Validator(value).apply { block(value) }.constraintViolations.map {
                 DefaultConstraintViolation(
-                    property = "${this.property.name}[$index].${it.property}",
+                    property = "${this.name()}[$index].${it.property}",
                     value = it.value,
                     constraint = it.constraint
                 )
@@ -62,17 +62,17 @@ inline fun <E, T> Validator<E>.Property<Array<T>?>.validateForEach(
  *
  * @param block specifies the function DSL
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("validateForEachIndexedArray")
-inline fun <E, T> Validator<E>.Property<Array<T>?>.validateForEachIndexed(
+inline fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.validateForEachIndexed(
     block: Validator<T>.(Int, T) -> Unit
-): Validator<E>.Property<Array<T>?> {
-    this.property.get(this.obj)?.forEachIndexed { index, value ->
+): Validator<E>.ReceiverValidator<E, Array<T>?> {
+    this.value()?.forEachIndexed { index, value ->
         this.addConstraintViolations(
             Validator(value).apply { block(index, value) }.constraintViolations.map {
                 DefaultConstraintViolation(
-                    property = "${this.property.name}[$index].${it.property}",
+                    property = "${this.name()}[$index].${it.property}",
                     value = it.value,
                     constraint = it.constraint
                 )
@@ -87,9 +87,9 @@ inline fun <E, T> Validator<E>.Property<Array<T>?>.validateForEachIndexed(
  *
  * @param value specifies the value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isEqualTo(value: Array<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isEqualTo(value: Array<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(Equals(value)) { it == null || it contentDeepEquals value }
 
 /**
@@ -97,9 +97,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.isEqualTo(value: Array<T>): Validato
  *
  * @param value specifies the value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isNotEqualTo(value: Array<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isNotEqualTo(value: Array<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotEquals(value)) { it == null || !(it contentDeepEquals value) }
 
 /**
@@ -107,9 +107,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.isNotEqualTo(value: Array<T>): Valid
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isIn(vararg values: Array<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isIn(vararg values: Array<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(In(values.toSet())) { it == null || values.any { e -> it contentDeepEquals e } }
 
 /**
@@ -117,9 +117,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.isIn(vararg values: Array<T>): Valid
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isIn(values: Iterable<Array<T>>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isIn(values: Iterable<Array<T>>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(In(values)) { it == null || values.any { e -> it contentDeepEquals e } }
 
 /**
@@ -127,9 +127,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.isIn(values: Iterable<Array<T>>): Va
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isNotIn(vararg values: Array<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isNotIn(vararg values: Array<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotIn(values.toSet())) { it == null || !values.any { e -> it contentDeepEquals e } }
 
 /**
@@ -137,27 +137,27 @@ fun <E, T> Validator<E>.Property<Array<T>?>.isNotIn(vararg values: Array<T>): Va
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isNotIn(values: Iterable<Array<T>>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isNotIn(values: Iterable<Array<T>>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotIn(values)) { it == null || !values.any { e -> it contentDeepEquals e } }
 
 /**
  * Validates if the array property is empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isEmpty(): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isEmpty(): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(Empty) { it == null || it.count() == 0 }
 
 /**
  * Validates if the array property is not empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.isNotEmpty(): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.isNotEmpty(): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotEmpty) { it == null || it.count() > 0 }
 
 /**
@@ -166,21 +166,21 @@ fun <E, T> Validator<E>.Property<Array<T>?>.isNotEmpty(): Validator<E>.Property<
  * @param min specifies the minimum size
  * @param max specifies the maximum size
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.hasSize(
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.hasSize(
     min: Int = Int.MIN_VALUE,
     max: Int = Int.MAX_VALUE
-): Validator<E>.Property<Array<T>?> = this.validate(Size(min, max)) { it == null || it.count() in min.rangeTo(max) }
+): Validator<E>.ReceiverValidator<E, Array<T>?> = this.validate(Size(min, max)) { it == null || it.count() in min.rangeTo(max) }
 
 /**
  * Validates if the array property contains the value
  *
  * @param value specifies the value that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.contains(value: T): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.contains(value: T): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(Contains(value)) { it == null || it.contains(value) }
 
 /**
@@ -188,9 +188,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.contains(value: T): Validator<E>.Pro
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.containsAll(vararg values: T): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.containsAll(vararg values: T): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(ContainsAll(values.toSet())) { it == null || values.toSet().all { e -> it.contains(e) } }
 
 /**
@@ -198,9 +198,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.containsAll(vararg values: T): Valid
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.containsAll(values: Iterable<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.containsAll(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(ContainsAll(values)) { it == null || values.all { e -> it.contains(e) } }
 
 /**
@@ -208,9 +208,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.containsAll(values: Iterable<T>): Va
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.containsAny(vararg values: T): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.containsAny(vararg values: T): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(ContainsAny(values.toSet())) { it == null || values.toSet().any { e -> it.contains(e) } }
 
 /**
@@ -218,9 +218,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.containsAny(vararg values: T): Valid
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.containsAny(values: Iterable<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.containsAny(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(ContainsAny(values)) { it == null || values.any { e -> it.contains(e) } }
 
 /**
@@ -228,9 +228,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.containsAny(values: Iterable<T>): Va
  *
  * @param value specifies the value that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContain(value: T): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.doesNotContain(value: T): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotContain(value)) { it == null || !it.contains(value) }
 
 /**
@@ -238,9 +238,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContain(value: T): Validator<
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContainAll(vararg values: T): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.doesNotContainAll(vararg values: T): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotContainAll(values.toSet())) { it == null || !values.toSet().all { e -> it.contains(e) } }
 
 /**
@@ -248,9 +248,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContainAll(vararg values: T):
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContainAll(values: Iterable<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.doesNotContainAll(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotContainAll(values)) { it == null || !values.all { e -> it.contains(e) } }
 
 /**
@@ -258,9 +258,9 @@ fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContainAll(values: Iterable<T
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContainAny(vararg values: T): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.doesNotContainAny(vararg values: T): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotContainAny(values.toSet())) { it == null || !values.toSet().any { e -> it.contains(e) } }
 
 /**
@@ -268,7 +268,7 @@ fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContainAny(vararg values: T):
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Array<T>?>.doesNotContainAny(values: Iterable<T>): Validator<E>.Property<Array<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Array<T>?>.doesNotContainAny(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Array<T>?> =
     this.validate(NotContainAny(values)) { it == null || !values.any { e -> it.contains(e) } }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/BigDecimalFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/BigDecimalFunctions.kt
@@ -34,9 +34,9 @@ import java.math.BigDecimal
  *
  * @param value specifies the value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isEqualTo(value: BigDecimal): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isEqualTo(value: BigDecimal): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(Equals(value)) { it == null || it.compareTo(value) == 0 }
 
 /**
@@ -44,9 +44,9 @@ fun <E> Validator<E>.Property<BigDecimal?>.isEqualTo(value: BigDecimal): Validat
  *
  * @param value specifies the value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isNotEqualTo(value: BigDecimal): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isNotEqualTo(value: BigDecimal): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(NotEquals(value)) { it == null || it.compareTo(value) != 0 }
 
 /**
@@ -54,9 +54,9 @@ fun <E> Validator<E>.Property<BigDecimal?>.isNotEqualTo(value: BigDecimal): Vali
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isIn(vararg values: BigDecimal): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isIn(vararg values: BigDecimal): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(In(values.toSet())) { it == null || values.any { e -> it.compareTo(e) == 0 } }
 
 /**
@@ -64,9 +64,9 @@ fun <E> Validator<E>.Property<BigDecimal?>.isIn(vararg values: BigDecimal): Vali
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isIn(values: Iterable<BigDecimal>): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isIn(values: Iterable<BigDecimal>): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(In(values)) { it == null || values.any { e -> it.compareTo(e) == 0 } }
 
 /**
@@ -74,9 +74,9 @@ fun <E> Validator<E>.Property<BigDecimal?>.isIn(values: Iterable<BigDecimal>): V
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isNotIn(vararg values: BigDecimal): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isNotIn(vararg values: BigDecimal): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(NotIn(values.toSet())) { it == null || !values.any { e -> it.compareTo(e) == 0 } }
 
 /**
@@ -84,81 +84,81 @@ fun <E> Validator<E>.Property<BigDecimal?>.isNotIn(vararg values: BigDecimal): V
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isNotIn(values: Iterable<BigDecimal>): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isNotIn(values: Iterable<BigDecimal>): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(NotIn(values)) { it == null || !values.any { e -> it.compareTo(e) == 0 } }
 
 /**
  * Validates if the [BigDecimal] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isZero(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isZero(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(Equals(BigDecimal.ZERO)) { it == null || it.compareTo(BigDecimal.ZERO) == 0 }
 
 /**
  * Validates if the [BigDecimal] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isNotZero(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isNotZero(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(NotEquals(BigDecimal.ZERO)) { it == null || it.compareTo(BigDecimal.ZERO) != 0 }
 
 /**
  * Validates if the [BigDecimal] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isOne(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isOne(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(Equals(BigDecimal.ONE)) { it == null || it.compareTo(BigDecimal.ONE) == 0 }
 
 /**
  * Validates if the [BigDecimal] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isNotOne(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isNotOne(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(NotEquals(BigDecimal.ONE)) { it == null || it.compareTo(BigDecimal.ONE) != 0 }
 
 /**
  * Validates if the [BigDecimal] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isPositive(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isPositive(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(Greater(BigDecimal.ZERO)) { it == null || it > BigDecimal.ZERO }
 
 /**
  * Validates if the [BigDecimal] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isPositiveOrZero(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(GreaterOrEqual(BigDecimal.ZERO)) { it == null || it >= BigDecimal.ZERO }
 
 /**
  * Validates if the [BigDecimal] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isNegative(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isNegative(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(Less(BigDecimal.ZERO)) { it == null || it < BigDecimal.ZERO }
 
 /**
  * Validates if the [BigDecimal] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.isNegativeOrZero(): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(LessOrEqual(BigDecimal.ZERO)) { it == null || it <= BigDecimal.ZERO }
 
 /**
@@ -168,9 +168,9 @@ fun <E> Validator<E>.Property<BigDecimal?>.isNegativeOrZero(): Validator<E>.Prop
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.precision() - it.scale() in min.rangeTo(max) }
 
 /**
@@ -180,7 +180,7 @@ fun <E> Validator<E>.Property<BigDecimal?>.hasIntegerDigits(min: Int = Int.MIN_V
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigDecimal?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<BigDecimal?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigDecimal?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, BigDecimal?> =
     this.validate(DecimalDigits(min, max)) { it == null || (if (it.scale() < 0) 0 else it.scale()) in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/BigIntegerFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/BigIntegerFunctions.kt
@@ -30,72 +30,72 @@ import java.math.BigInteger
  * Validates if the [BigInteger] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isZero(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isZero(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(Equals(BigInteger.ZERO)) { it == null || it == BigInteger.ZERO }
 
 /**
  * Validates if the [BigInteger] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isNotZero(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isNotZero(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(NotEquals(BigInteger.ZERO)) { it == null || it != BigInteger.ZERO }
 
 /**
  * Validates if the [BigInteger] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isOne(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isOne(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(Equals(BigInteger.ONE)) { it == null || it == BigInteger.ONE }
 
 /**
  * Validates if the [BigInteger] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isNotOne(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isNotOne(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(NotEquals(BigInteger.ONE)) { it == null || it != BigInteger.ONE }
 
 /**
  * Validates if the [BigInteger] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isPositive(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isPositive(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(Greater(BigInteger.ZERO)) { it == null || it > BigInteger.ZERO }
 
 /**
  * Validates if the [BigInteger] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isPositiveOrZero(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(GreaterOrEqual(BigInteger.ZERO)) { it == null || it >= BigInteger.ZERO }
 
 /**
  * Validates if the [BigInteger] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isNegative(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isNegative(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(Less(BigInteger.ZERO)) { it == null || it < BigInteger.ZERO }
 
 /**
  * Validates if the [BigInteger] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.isNegativeOrZero(): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(LessOrEqual(BigInteger.ZERO)) { it == null || it <= BigInteger.ZERO }
 
 /**
@@ -105,7 +105,7 @@ fun <E> Validator<E>.Property<BigInteger?>.isNegativeOrZero(): Validator<E>.Prop
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigInteger?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<BigInteger?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigInteger?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, BigInteger?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.toString().removePrefix("-").length in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/BooleanFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/BooleanFunctions.kt
@@ -24,16 +24,16 @@ import org.valiktor.constraints.True
  * Validates if the [Boolean] property is true
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Boolean?>.isTrue(): Validator<E>.Property<Boolean?> =
+fun <E> Validator<E>.ReceiverValidator<E, Boolean?>.isTrue(): Validator<E>.ReceiverValidator<E, Boolean?> =
     this.validate(True) { it == null || it }
 
 /**
  * Validates if the [Boolean] property is false
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Boolean?>.isFalse(): Validator<E>.Property<Boolean?> =
+fun <E> Validator<E>.ReceiverValidator<E, Boolean?>.isFalse(): Validator<E>.ReceiverValidator<E, Boolean?> =
     this.validate(False) { it == null || !it }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/ByteFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/ByteFunctions.kt
@@ -29,72 +29,72 @@ import org.valiktor.constraints.NotEquals
  * Validates if the [Byte] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isZero(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isZero(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(Equals<Byte>(0)) { it == null || it == 0.toByte() }
 
 /**
  * Validates if the [Byte] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isNotZero(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isNotZero(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(NotEquals<Byte>(0)) { it == null || it != 0.toByte() }
 
 /**
  * Validates if the [Byte] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isOne(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isOne(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(Equals<Byte>(1)) { it == null || it == 1.toByte() }
 
 /**
  * Validates if the [Byte] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isNotOne(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isNotOne(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(NotEquals<Byte>(1)) { it == null || it != 1.toByte() }
 
 /**
  * Validates if the [Byte] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isPositive(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isPositive(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(Greater<Byte>(0)) { it == null || it > 0.toByte() }
 
 /**
  * Validates if the [Byte] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isPositiveOrZero(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(GreaterOrEqual<Byte>(0)) { it == null || it >= 0.toByte() }
 
 /**
  * Validates if the [Byte] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isNegative(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isNegative(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(Less<Byte>(0)) { it == null || it < 0.toByte() }
 
 /**
  * Validates if the [Byte] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.isNegativeOrZero(): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(LessOrEqual<Byte>(0)) { it == null || it <= 0.toByte() }
 
 /**
@@ -104,7 +104,7 @@ fun <E> Validator<E>.Property<Byte?>.isNegativeOrZero(): Validator<E>.Property<B
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Byte?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Byte?> =
+fun <E> Validator<E>.ReceiverValidator<E, Byte?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Byte?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.toString().removePrefix("-").length in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/CalendarFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/CalendarFunctions.kt
@@ -25,9 +25,9 @@ import java.util.Calendar
  * Validates if the [Calendar] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Calendar?>.isToday(): Validator<E>.Property<Calendar?> {
+fun <E> Validator<E>.ReceiverValidator<E, Calendar?>.isToday(): Validator<E>.ReceiverValidator<E, Calendar?> {
     val start = Calendar.getInstance()
     start.set(Calendar.HOUR_OF_DAY, 0)
     start.set(Calendar.MINUTE, 0)
@@ -47,9 +47,9 @@ fun <E> Validator<E>.Property<Calendar?>.isToday(): Validator<E>.Property<Calend
  * Validates if the [Calendar] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Calendar?>.isNotToday(): Validator<E>.Property<Calendar?> {
+fun <E> Validator<E>.ReceiverValidator<E, Calendar?>.isNotToday(): Validator<E>.ReceiverValidator<E, Calendar?> {
     val start = Calendar.getInstance()
     start.set(Calendar.HOUR_OF_DAY, 0)
     start.set(Calendar.MINUTE, 0)

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/CharFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/CharFunctions.kt
@@ -36,90 +36,90 @@ import org.valiktor.constraints.UpperCase
  * Validates if the [Char] property is a whitespace
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isWhitespace(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isWhitespace(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(Blank) { it == null || it.isWhitespace() }
 
 /**
  * Validates if the [Char] property is not a whitespace
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isNotWhitespace(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isNotWhitespace(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(NotBlank) { it == null || !it.isWhitespace() }
 
 /**
  * Validates if the [Char] property is a letter
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isLetter(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isLetter(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(Letter) { it == null || it.isLetter() }
 
 /**
  * Validates if the [Char] property is not a letter
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isNotLetter(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isNotLetter(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(NotLetter) { it == null || !it.isLetter() }
 
 /**
  * Validates if the [Char] property is a digit
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isDigit(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isDigit(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(Digit) { it == null || it.isDigit() }
 
 /**
  * Validates if the [Char] property is not a digit
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isNotDigit(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isNotDigit(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(NotDigit) { it == null || !it.isDigit() }
 
 /**
  * Validates if the [Char] property is a letter or a digit
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isLetterOrDigit(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isLetterOrDigit(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(LetterOrDigit) { it == null || it.isLetterOrDigit() }
 
 /**
  * Validates if the [Char] property is not a letter or a digit
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isNotLetterOrDigit(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isNotLetterOrDigit(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(NotLetterOrDigit) { it == null || !it.isLetterOrDigit() }
 
 /**
  * Validates if the [Char] property is uppercase
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isUpperCase(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isUpperCase(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(UpperCase) { it == null || it.isUpperCase() }
 
 /**
  * Validates if the [Char] property is lowercase
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isLowerCase(): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isLowerCase(): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(LowerCase) { it == null || it.isLowerCase() }
 
 /**
@@ -127,9 +127,9 @@ fun <E> Validator<E>.Property<Char?>.isLowerCase(): Validator<E>.Property<Char?>
  *
  * @param value specifies the value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isEqualToIgnoringCase(value: Char): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isEqualToIgnoringCase(value: Char): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(Equals(value)) { it == null || it.equals(other = value, ignoreCase = true) }
 
 /**
@@ -137,9 +137,9 @@ fun <E> Validator<E>.Property<Char?>.isEqualToIgnoringCase(value: Char): Validat
  *
  * @param value specifies the value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isNotEqualToIgnoringCase(value: Char): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isNotEqualToIgnoringCase(value: Char): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(NotEquals(value)) { it == null || !it.equals(other = value, ignoreCase = true) }
 
 /**
@@ -147,9 +147,9 @@ fun <E> Validator<E>.Property<Char?>.isNotEqualToIgnoringCase(value: Char): Vali
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isInIgnoringCase(vararg values: Char): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isInIgnoringCase(vararg values: Char): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(In(values.toSet())) { it == null || values.toSet().any { e -> it.equals(other = e, ignoreCase = true) } }
 
 /**
@@ -157,9 +157,9 @@ fun <E> Validator<E>.Property<Char?>.isInIgnoringCase(vararg values: Char): Vali
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isInIgnoringCase(values: Iterable<Char>): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isInIgnoringCase(values: Iterable<Char>): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(In(values)) { it == null || values.any { e -> it.equals(other = e, ignoreCase = true) } }
 
 /**
@@ -167,9 +167,9 @@ fun <E> Validator<E>.Property<Char?>.isInIgnoringCase(values: Iterable<Char>): V
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isNotInIgnoringCase(vararg values: Char): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isNotInIgnoringCase(vararg values: Char): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(NotIn(values.toSet())) { it == null || values.toSet().none { e -> it.equals(other = e, ignoreCase = true) } }
 
 /**
@@ -177,7 +177,7 @@ fun <E> Validator<E>.Property<Char?>.isNotInIgnoringCase(vararg values: Char): V
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Char?>.isNotInIgnoringCase(values: Iterable<Char>): Validator<E>.Property<Char?> =
+fun <E> Validator<E>.ReceiverValidator<E, Char?>.isNotInIgnoringCase(values: Iterable<Char>): Validator<E>.ReceiverValidator<E, Char?> =
     this.validate(NotIn(values)) { it == null || values.none { e -> it.equals(other = e, ignoreCase = true) } }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/ComparableFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/ComparableFunctions.kt
@@ -30,9 +30,9 @@ import org.valiktor.constraints.NotBetween
  * @property value specifies the value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isLessThan(value: T): Validator<E>.Property<T?> =
+fun <E, T : Comparable<T>> Validator<E>.ReceiverValidator<E, T?>.isLessThan(value: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(Less(value)) { it == null || it < value }
 
 /**
@@ -41,9 +41,9 @@ fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isLessThan(value: T): Valid
  * @property value specifies the value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isLessThanOrEqualTo(value: T): Validator<E>.Property<T?> =
+fun <E, T : Comparable<T>> Validator<E>.ReceiverValidator<E, T?>.isLessThanOrEqualTo(value: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(LessOrEqual(value)) { it == null || it <= value }
 
 /**
@@ -52,9 +52,9 @@ fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isLessThanOrEqualTo(value: 
  * @property value specifies the value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isGreaterThan(value: T): Validator<E>.Property<T?> =
+fun <E, T : Comparable<T>> Validator<E>.ReceiverValidator<E, T?>.isGreaterThan(value: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(Greater(value)) { it == null || it > value }
 
 /**
@@ -63,9 +63,9 @@ fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isGreaterThan(value: T): Va
  * @property value specifies the value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isGreaterThanOrEqualTo(value: T): Validator<E>.Property<T?> =
+fun <E, T : Comparable<T>> Validator<E>.ReceiverValidator<E, T?>.isGreaterThanOrEqualTo(value: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(GreaterOrEqual(value)) { it == null || it >= value }
 
 /**
@@ -75,9 +75,9 @@ fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isGreaterThanOrEqualTo(valu
  * @property end (inclusive) specifies value that should end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isBetween(start: T, end: T): Validator<E>.Property<T?> =
+fun <E, T : Comparable<T>> Validator<E>.ReceiverValidator<E, T?>.isBetween(start: T, end: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(Between(start, end)) { it == null || it in start.rangeTo(end) }
 
 /**
@@ -87,7 +87,7 @@ fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isBetween(start: T, end: T)
  * @property end (inclusive) specifies value that shouldn't end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : Comparable<T>> Validator<E>.Property<T?>.isNotBetween(start: T, end: T): Validator<E>.Property<T?> =
+fun <E, T : Comparable<T>> Validator<E>.ReceiverValidator<E, T?>.isNotBetween(start: T, end: T): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(NotBetween(start, end)) { it == null || it !in start.rangeTo(end) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/DateFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/DateFunctions.kt
@@ -26,9 +26,9 @@ import java.util.Date
  * Validates if the [Date] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Date?>.isToday(): Validator<E>.Property<Date?> {
+fun <E> Validator<E>.ReceiverValidator<E, Date?>.isToday(): Validator<E>.ReceiverValidator<E, Date?> {
     val start = Calendar.getInstance()
     start.set(Calendar.HOUR_OF_DAY, 0)
     start.set(Calendar.MINUTE, 0)
@@ -48,9 +48,9 @@ fun <E> Validator<E>.Property<Date?>.isToday(): Validator<E>.Property<Date?> {
  * Validates if the [Date] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Date?>.isNotToday(): Validator<E>.Property<Date?> {
+fun <E> Validator<E>.ReceiverValidator<E, Date?>.isNotToday(): Validator<E>.ReceiverValidator<E, Date?> {
     val start = Calendar.getInstance()
     start.set(Calendar.HOUR_OF_DAY, 0)
     start.set(Calendar.MINUTE, 0)

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/DoubleFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/DoubleFunctions.kt
@@ -30,72 +30,72 @@ import org.valiktor.constraints.NotEquals
  * Validates if the [Double] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isZero(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isZero(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(Equals(0.0)) { it == null || it == 0.0 }
 
 /**
  * Validates if the [Double] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isNotZero(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isNotZero(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(NotEquals(0.0)) { it == null || it != 0.0 }
 
 /**
  * Validates if the [Double] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isOne(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isOne(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(Equals(1.0)) { it == null || it == 1.0 }
 
 /**
  * Validates if the [Double] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isNotOne(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isNotOne(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(NotEquals(1.0)) { it == null || it != 1.0 }
 
 /**
  * Validates if the [Double] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isPositive(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isPositive(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(Greater(0.0)) { it == null || it > 0.0 }
 
 /**
  * Validates if the [Double] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isPositiveOrZero(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(GreaterOrEqual(0.0)) { it == null || it >= 0.0 }
 
 /**
  * Validates if the [Double] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isNegative(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isNegative(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(Less(0.0)) { it == null || it < 0.0 }
 
 /**
  * Validates if the [Double] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.isNegativeOrZero(): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(LessOrEqual(0.0)) { it == null || it <= 0.0 }
 
 /**
@@ -105,9 +105,9 @@ fun <E> Validator<E>.Property<Double?>.isNegativeOrZero(): Validator<E>.Property
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.toString().removePrefix("-").split(".")[0].length in min.rangeTo(max) }
 
 /**
@@ -117,7 +117,7 @@ fun <E> Validator<E>.Property<Double?>.hasIntegerDigits(min: Int = Int.MIN_VALUE
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Double?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Double?> =
+fun <E> Validator<E>.ReceiverValidator<E, Double?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Double?> =
     this.validate(DecimalDigits(min, max)) { it == null || it.toString().removePrefix("-").split(".")[1].length in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/FloatFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/FloatFunctions.kt
@@ -30,72 +30,72 @@ import org.valiktor.constraints.NotEquals
  * Validates if the [Float] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isZero(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isZero(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(Equals(0f)) { it == null || it == 0f }
 
 /**
  * Validates if the [Float] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isNotZero(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isNotZero(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(NotEquals(0f)) { it == null || it != 0f }
 
 /**
  * Validates if the [Float] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isOne(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isOne(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(Equals(1f)) { it == null || it == 1f }
 
 /**
  * Validates if the [Float] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isNotOne(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isNotOne(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(NotEquals(1f)) { it == null || it != 1f }
 
 /**
  * Validates if the [Float] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isPositive(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isPositive(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(Greater(0f)) { it == null || it > 0f }
 
 /**
  * Validates if the [Float] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isPositiveOrZero(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(GreaterOrEqual(0f)) { it == null || it >= 0f }
 
 /**
  * Validates if the [Float] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isNegative(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isNegative(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(Less(0f)) { it == null || it < 0f }
 
 /**
  * Validates if the [Float] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.isNegativeOrZero(): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(LessOrEqual(0f)) { it == null || it <= 0f }
 
 /**
@@ -105,9 +105,9 @@ fun <E> Validator<E>.Property<Float?>.isNegativeOrZero(): Validator<E>.Property<
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.toString().removePrefix("-").split(".")[0].length in min.rangeTo(max) }
 
 /**
@@ -117,7 +117,7 @@ fun <E> Validator<E>.Property<Float?>.hasIntegerDigits(min: Int = Int.MIN_VALUE,
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Float?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Float?> =
+fun <E> Validator<E>.ReceiverValidator<E, Float?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Float?> =
     this.validate(DecimalDigits(min, max)) { it == null || it.toString().removePrefix("-").split(".")[1].length in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/IntFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/IntFunctions.kt
@@ -29,72 +29,72 @@ import org.valiktor.constraints.NotEquals
  * Validates if the [Int] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isZero(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isZero(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(Equals(0)) { it == null || it == 0 }
 
 /**
  * Validates if the [Int] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isNotZero(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isNotZero(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(NotEquals(0)) { it == null || it != 0 }
 
 /**
  * Validates if the [Int] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isOne(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isOne(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(Equals(1)) { it == null || it == 1 }
 
 /**
  * Validates if the [Int] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isNotOne(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isNotOne(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(NotEquals(1)) { it == null || it != 1 }
 
 /**
  * Validates if the [Int] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isPositive(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isPositive(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(Greater(0)) { it == null || it > 0 }
 
 /**
  * Validates if the [Int] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isPositiveOrZero(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(GreaterOrEqual(0)) { it == null || it >= 0 }
 
 /**
  * Validates if the [Int] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isNegative(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isNegative(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(Less(0)) { it == null || it < 0 }
 
 /**
  * Validates if the [Int] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.isNegativeOrZero(): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(LessOrEqual(0)) { it == null || it <= 0 }
 
 /**
@@ -104,7 +104,7 @@ fun <E> Validator<E>.Property<Int?>.isNegativeOrZero(): Validator<E>.Property<In
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Int?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Int?> =
+fun <E> Validator<E>.ReceiverValidator<E, Int?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Int?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.toString().removePrefix("-").length in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/IterableFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/IterableFunctions.kt
@@ -35,17 +35,17 @@ import org.valiktor.constraints.Size
  *
  * @param block specifies the function DSL
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("validateForEachIterable")
-inline fun <E, T> Validator<E>.Property<Iterable<T>?>.validateForEach(
+inline fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.validateForEach(
     block: Validator<T>.(T) -> Unit
-): Validator<E>.Property<Iterable<T>?> {
-    this.property.get(this.obj)?.forEachIndexed { index, value ->
+): Validator<E>.ReceiverValidator<E, Iterable<T>?> {
+    this.value()?.forEachIndexed { index, value ->
         this.addConstraintViolations(
             Validator(value).apply { block(value) }.constraintViolations.map {
                 DefaultConstraintViolation(
-                    property = "${this.property.name}[$index].${it.property}",
+                    property = "${this.name()}[$index].${it.property}",
                     value = it.value,
                     constraint = it.constraint
                 )
@@ -60,17 +60,17 @@ inline fun <E, T> Validator<E>.Property<Iterable<T>?>.validateForEach(
  *
  * @param block specifies the function DSL
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("validateForEachIndexedIterable")
-inline fun <E, T> Validator<E>.Property<Iterable<T>?>.validateForEachIndexed(
+inline fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.validateForEachIndexed(
     block: Validator<T>.(Int, T) -> Unit
-): Validator<E>.Property<Iterable<T>?> {
-    this.property.get(this.obj)?.forEachIndexed { index, value ->
+): Validator<E>.ReceiverValidator<E, Iterable<T>?> {
+    this.value()?.forEachIndexed { index, value ->
         this.addConstraintViolations(
             Validator(value).apply { block(index, value) }.constraintViolations.map {
                 DefaultConstraintViolation(
-                    property = "${this.property.name}[$index].${it.property}",
+                    property = "${this.name()}[$index].${it.property}",
                     value = it.value,
                     constraint = it.constraint
                 )
@@ -85,9 +85,9 @@ inline fun <E, T> Validator<E>.Property<Iterable<T>?>.validateForEachIndexed(
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.isIn(vararg values: Iterable<T>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.isIn(vararg values: Iterable<T>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(In(values.toSet())) { it == null || values.contains(it) }
 
 /**
@@ -95,9 +95,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.isIn(vararg values: Iterable<T>):
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.isIn(values: Iterable<Iterable<T>>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.isIn(values: Iterable<Iterable<T>>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(In(values)) { it == null || values.contains(it) }
 
 /**
@@ -105,9 +105,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.isIn(values: Iterable<Iterable<T>
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.isNotIn(vararg values: Iterable<T>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.isNotIn(vararg values: Iterable<T>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotIn(values.toSet())) { it == null || !values.contains(it) }
 
 /**
@@ -115,27 +115,27 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.isNotIn(vararg values: Iterable<T
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.isNotIn(values: Iterable<Iterable<T>>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.isNotIn(values: Iterable<Iterable<T>>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotIn(values)) { it == null || !values.contains(it) }
 
 /**
  * Validates if the [Iterable] property is empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.isEmpty(): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.isEmpty(): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(Empty) { it == null || it.count() == 0 }
 
 /**
  * Validates if the [Iterable] property is not empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.isNotEmpty(): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.isNotEmpty(): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotEmpty) { it == null || it.count() > 0 }
 
 /**
@@ -144,21 +144,21 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.isNotEmpty(): Validator<E>.Proper
  * @param min specifies the minimum size
  * @param max specifies the maximum size
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.hasSize(
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.hasSize(
     min: Int = Int.MIN_VALUE,
     max: Int = Int.MAX_VALUE
-): Validator<E>.Property<Iterable<T>?> = this.validate(Size(min, max)) { it == null || it.count() in min.rangeTo(max) }
+): Validator<E>.ReceiverValidator<E, Iterable<T>?> = this.validate(Size(min, max)) { it == null || it.count() in min.rangeTo(max) }
 
 /**
  * Validates if the [Iterable] property contains the value
  *
  * @param value specifies the value that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.contains(value: T): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.contains(value: T): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(Contains(value)) { it == null || it.contains(value) }
 
 /**
@@ -166,9 +166,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.contains(value: T): Validator<E>.
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAll(vararg values: T): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.containsAll(vararg values: T): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(ContainsAll(values.toSet())) { it == null || values.toSet().all { e -> it.contains(e) } }
 
 /**
@@ -176,9 +176,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAll(vararg values: T): Va
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAll(values: Iterable<T>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.containsAll(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(ContainsAll(values)) { it == null || values.all { e -> it.contains(e) } }
 
 /**
@@ -186,9 +186,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAll(values: Iterable<T>):
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAny(vararg values: T): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.containsAny(vararg values: T): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(ContainsAny(values.toSet())) { it == null || values.toSet().any { e -> it.contains(e) } }
 
 /**
@@ -196,9 +196,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAny(vararg values: T): Va
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAny(values: Iterable<T>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.containsAny(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(ContainsAny(values)) { it == null || values.any { e -> it.contains(e) } }
 
 /**
@@ -206,9 +206,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.containsAny(values: Iterable<T>):
  *
  * @param value specifies the value that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContain(value: T): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.doesNotContain(value: T): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotContain(value)) { it == null || !it.contains(value) }
 
 /**
@@ -216,9 +216,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContain(value: T): Validat
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContainAll(vararg values: T): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.doesNotContainAll(vararg values: T): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotContainAll(values.toSet())) { it == null || !values.toSet().all { e -> it.contains(e) } }
 
 /**
@@ -226,9 +226,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContainAll(vararg values: 
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContainAll(values: Iterable<T>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.doesNotContainAll(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotContainAll(values)) { it == null || !values.all { e -> it.contains(e) } }
 
 /**
@@ -236,9 +236,9 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContainAll(values: Iterabl
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContainAny(vararg values: T): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.doesNotContainAny(vararg values: T): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotContainAny(values.toSet())) { it == null || !values.toSet().any { e -> it.contains(e) } }
 
 /**
@@ -246,7 +246,7 @@ fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContainAny(vararg values: 
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T> Validator<E>.Property<Iterable<T>?>.doesNotContainAny(values: Iterable<T>): Validator<E>.Property<Iterable<T>?> =
+fun <E, T> Validator<E>.ReceiverValidator<E, Iterable<T>?>.doesNotContainAny(values: Iterable<T>): Validator<E>.ReceiverValidator<E, Iterable<T>?> =
     this.validate(NotContainAny(values)) { it == null || !values.any { e -> it.contains(e) } }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/LongFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/LongFunctions.kt
@@ -29,72 +29,72 @@ import org.valiktor.constraints.NotEquals
  * Validates if the [Long] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isZero(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isZero(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(Equals(0L)) { it == null || it == 0L }
 
 /**
  * Validates if the [Long] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isNotZero(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isNotZero(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(NotEquals(0L)) { it == null || it != 0L }
 
 /**
  * Validates if the [Long] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isOne(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isOne(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(Equals(1L)) { it == null || it == 1L }
 
 /**
  * Validates if the [Long] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isNotOne(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isNotOne(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(NotEquals(1L)) { it == null || it != 1L }
 
 /**
  * Validates if the [Long] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isPositive(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isPositive(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(Greater(0L)) { it == null || it > 0L }
 
 /**
  * Validates if the [Long] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isPositiveOrZero(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(GreaterOrEqual(0L)) { it == null || it >= 0L }
 
 /**
  * Validates if the [Long] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isNegative(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isNegative(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(Less(0L)) { it == null || it < 0L }
 
 /**
  * Validates if the [Long] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.isNegativeOrZero(): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(LessOrEqual(0L)) { it == null || it <= 0L }
 
 /**
@@ -104,7 +104,7 @@ fun <E> Validator<E>.Property<Long?>.isNegativeOrZero(): Validator<E>.Property<L
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Long?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Long?> =
+fun <E> Validator<E>.ReceiverValidator<E, Long?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Long?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.toString().removePrefix("-").length in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/MapFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/MapFunctions.kt
@@ -14,18 +14,18 @@ import org.valiktor.constraints.NotEmpty
  * Validates if the [Map] property is empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.isEmpty(): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.isEmpty(): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(Empty) { it == null || it.isEmpty() }
 
 /**
  * Validates if the [Map] property is not empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.isNotEmpty(): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.isNotEmpty(): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotEmpty) { it == null || it.isNotEmpty() }
 
 /**
@@ -33,9 +33,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.isNotEmpty(): Validator<E>.Prope
  *
  * @param key specifies the key that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsKey(key: K): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsKey(key: K): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(Contains(key)) { it == null || it.containsKey(key) }
 
 /**
@@ -43,9 +43,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsKey(key: K): Validator<E
  *
  * @param keys specifies the all keys that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllKeys(vararg keys: K): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAllKeys(vararg keys: K): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAll(keys.toSet())) { it == null || keys.all { e -> it.containsKey(e) } }
 
 /**
@@ -53,9 +53,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllKeys(vararg keys: K):
  *
  * @param keys specifies the all keys that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllKeys(keys: Iterable<K>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAllKeys(keys: Iterable<K>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAll(keys)) { it == null || keys.all { e -> it.containsKey(e) } }
 
 /**
@@ -63,9 +63,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllKeys(keys: Iterable<K
  *
  * @param keys specifies the keys that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyKey(vararg keys: K): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAnyKey(vararg keys: K): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAny(keys.toSet())) { it == null || keys.any { e -> it.containsKey(e) } }
 
 /**
@@ -73,9 +73,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyKey(vararg keys: K): 
  *
  * @param keys specifies the keys that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyKey(keys: Iterable<K>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAnyKey(keys: Iterable<K>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAny(keys)) { it == null || keys.any { e -> it.containsKey(e) } }
 
 /**
@@ -83,9 +83,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyKey(keys: Iterable<K>
  *
  * @param key specifies the key that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainKey(key: K): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainKey(key: K): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContain(key)) { it == null || !it.containsKey(key) }
 
 /**
@@ -93,9 +93,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainKey(key: K): Valid
  *
  * @param keys specifies the all keys that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllKeys(vararg keys: K): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAllKeys(vararg keys: K): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAll(keys.toSet())) { it == null || !keys.all { e -> it.containsKey(e) } }
 
 /**
@@ -103,9 +103,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllKeys(vararg key
  *
  * @param keys specifies the all keys that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllKeys(keys: Iterable<K>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAllKeys(keys: Iterable<K>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAll(keys)) { it == null || !keys.all { e -> it.containsKey(e) } }
 
 /**
@@ -113,9 +113,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllKeys(keys: Iter
  *
  * @param keys specifies the keys that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAnyKey(vararg keys: K): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAnyKey(vararg keys: K): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAny(keys.toSet())) { it == null || !keys.any { e -> it.containsKey(e) } }
 
 /**
@@ -123,9 +123,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAnyKey(vararg keys
  *
  * @param keys specifies the keys that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAnyKey(keys: Iterable<K>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAnyKey(keys: Iterable<K>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAny(keys)) { it == null || !keys.any { e -> it.containsKey(e) } }
 
 /**
@@ -133,9 +133,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAnyKey(keys: Itera
  *
  * @param value specifies the value that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsValue(value: V): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsValue(value: V): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(Contains(value)) { it == null || it.containsValue(value) }
 
 /**
@@ -143,9 +143,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsValue(value: V): Validat
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllValues(vararg values: V): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAllValues(vararg values: V): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAll(values.toSet())) { it == null || values.all { e -> it.containsValue(e) } }
 
 /**
@@ -153,9 +153,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllValues(vararg values:
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllValues(values: Iterable<V>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAllValues(values: Iterable<V>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAll(values)) { it == null || values.all { e -> it.containsValue(e) } }
 
 /**
@@ -163,9 +163,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAllValues(values: Iterab
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyValue(vararg values: V): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAnyValue(vararg values: V): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAny(values.toSet())) { it == null || values.any { e -> it.containsValue(e) } }
 
 /**
@@ -173,9 +173,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyValue(vararg values: 
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyValue(values: Iterable<V>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.containsAnyValue(values: Iterable<V>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(ContainsAny(values)) { it == null || values.any { e -> it.containsValue(e) } }
 
 /**
@@ -183,9 +183,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.containsAnyValue(values: Iterabl
  *
  * @param value specifies the value that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainValue(value: V): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainValue(value: V): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContain(value)) { it == null || !it.containsValue(value) }
 
 /**
@@ -193,9 +193,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainValue(value: V): V
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllValues(vararg values: V): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAllValues(vararg values: V): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAll(values.toSet())) { it == null || !values.all { e -> it.containsValue(e) } }
 
 /**
@@ -203,9 +203,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllValues(vararg v
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllValues(values: Iterable<V>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAllValues(values: Iterable<V>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAll(values)) { it == null || !values.all { e -> it.containsValue(e) } }
 
 /**
@@ -213,9 +213,9 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAllValues(values: 
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAnyValue(vararg values: V): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAnyValue(vararg values: V): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAny(values.toSet())) { it == null || !values.any { e -> it.containsValue(e) } }
 
 /**
@@ -223,7 +223,7 @@ fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAnyValue(vararg va
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, K, V> Validator<E>.Property<Map<K, V>?>.doesNotContainAnyValue(values: Iterable<V>): Validator<E>.Property<Map<K, V>?> =
+fun <E, K, V> Validator<E>.ReceiverValidator<E, Map<K, V>?>.doesNotContainAnyValue(values: Iterable<V>): Validator<E>.ReceiverValidator<E, Map<K, V>?> =
     this.validate(NotContainAny(values)) { it == null || !values.any { e -> it.containsValue(e) } }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/ShortFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/ShortFunctions.kt
@@ -29,72 +29,72 @@ import org.valiktor.constraints.NotEquals
  * Validates if the [Short] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isZero(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isZero(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(Equals<Short>(0)) { it == null || it == 0.toShort() }
 
 /**
  * Validates if the [Short] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isNotZero(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isNotZero(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(NotEquals<Short>(0)) { it == null || it != 0.toShort() }
 
 /**
  * Validates if the [Short] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isOne(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isOne(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(Equals<Short>(1)) { it == null || it == 1.toShort() }
 
 /**
  * Validates if the [Short] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isNotOne(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isNotOne(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(NotEquals<Short>(1)) { it == null || it != 1.toShort() }
 
 /**
  * Validates if the [Short] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isPositive(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isPositive(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(Greater<Short>(0)) { it == null || it > 0.toShort() }
 
 /**
  * Validates if the [Short] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isPositiveOrZero(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(GreaterOrEqual<Short>(0)) { it == null || it >= 0.toShort() }
 
 /**
  * Validates if the [Short] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isNegative(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isNegative(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(Less<Short>(0)) { it == null || it < 0.toShort() }
 
 /**
  * Validates if the [Short] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.isNegativeOrZero(): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(LessOrEqual<Short>(0)) { it == null || it <= 0.toShort() }
 
 /**
@@ -104,7 +104,7 @@ fun <E> Validator<E>.Property<Short?>.isNegativeOrZero(): Validator<E>.Property<
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Short?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Short?> =
+fun <E> Validator<E>.ReceiverValidator<E, Short?>.hasDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Short?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.toString().removePrefix("-").length in min.rangeTo(max) }

--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/StringFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/StringFunctions.kt
@@ -47,36 +47,36 @@ import org.valiktor.constraints.Website
  * Validates if the [String] property is empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isEmpty(): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isEmpty(): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Empty) { it == null || it.isEmpty() }
 
 /**
  * Validates if the [String] property is not empty
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isNotEmpty(): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isNotEmpty(): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotEmpty) { it == null || it.isNotEmpty() }
 
 /**
  * Validates if the [String] property is blank
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isBlank(): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isBlank(): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Blank) { it == null || it.isBlank() }
 
 /**
  * Validates if the [String] property is not blank
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isNotBlank(): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isNotBlank(): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotBlank) { it == null || it.isNotBlank() }
 
 /**
@@ -84,9 +84,9 @@ fun <E> Validator<E>.Property<String?>.isNotBlank(): Validator<E>.Property<Strin
  *
  * @param value specifies the value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isEqualToIgnoringCase(value: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isEqualToIgnoringCase(value: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Equals(value)) { it == null || it.equals(other = value, ignoreCase = true) }
 
 /**
@@ -94,9 +94,9 @@ fun <E> Validator<E>.Property<String?>.isEqualToIgnoringCase(value: String): Val
  *
  * @param value specifies the value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isNotEqualToIgnoringCase(value: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isNotEqualToIgnoringCase(value: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotEquals(value)) { it == null || !it.equals(other = value, ignoreCase = true) }
 
 /**
@@ -104,9 +104,9 @@ fun <E> Validator<E>.Property<String?>.isNotEqualToIgnoringCase(value: String): 
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isInIgnoringCase(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isInIgnoringCase(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(In(values.toSet())) { it == null || values.toSet().any { e -> it.equals(other = e, ignoreCase = true) } }
 
 /**
@@ -114,9 +114,9 @@ fun <E> Validator<E>.Property<String?>.isInIgnoringCase(vararg values: String): 
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isInIgnoringCase(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isInIgnoringCase(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(In(values)) { it == null || values.any { e -> it.equals(other = e, ignoreCase = true) } }
 
 /**
@@ -124,9 +124,9 @@ fun <E> Validator<E>.Property<String?>.isInIgnoringCase(values: Iterable<String>
  *
  * @param values specifies the array of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isNotInIgnoringCase(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isNotInIgnoringCase(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotIn(values.toSet())) { it == null || values.toSet().none { e -> it.equals(other = e, ignoreCase = true) } }
 
 /**
@@ -134,9 +134,9 @@ fun <E> Validator<E>.Property<String?>.isNotInIgnoringCase(vararg values: String
  *
  * @param values specifies the iterable of values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isNotInIgnoringCase(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isNotInIgnoringCase(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotIn(values)) { it == null || values.none { e -> it.equals(other = e, ignoreCase = true) } }
 
 /**
@@ -145,9 +145,9 @@ fun <E> Validator<E>.Property<String?>.isNotInIgnoringCase(values: Iterable<Stri
  * @param min specifies the minimum size
  * @param max specifies the maximum size
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.hasSize(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.hasSize(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Size(min, max)) { it == null || it.length in min.rangeTo(max) }
 
 /**
@@ -155,9 +155,9 @@ fun <E> Validator<E>.Property<String?>.hasSize(min: Int = Int.MIN_VALUE, max: In
  *
  * @param value specifies the value that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.contains(value: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.contains(value: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Contains(value)) { it == null || it.contains(value) }
 
 /**
@@ -165,9 +165,9 @@ fun <E> Validator<E>.Property<String?>.contains(value: String): Validator<E>.Pro
  *
  * @param value specifies the value that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsIgnoringCase(value: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsIgnoringCase(value: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Contains(value)) { it == null || it.contains(other = value, ignoreCase = true) }
 
 /**
@@ -175,9 +175,9 @@ fun <E> Validator<E>.Property<String?>.containsIgnoringCase(value: String): Vali
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAll(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAll(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAll(values.toSet())) { it == null || values.toSet().all { e -> it.contains(e) } }
 
 /**
@@ -185,9 +185,9 @@ fun <E> Validator<E>.Property<String?>.containsAll(vararg values: String): Valid
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAll(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAll(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAll(values)) { it == null || values.all { e -> it.contains(e) } }
 
 /**
@@ -195,9 +195,9 @@ fun <E> Validator<E>.Property<String?>.containsAll(values: Iterable<String>): Va
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAllIgnoringCase(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAllIgnoringCase(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAll(values.toSet())) { it == null || values.toSet().all { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -205,9 +205,9 @@ fun <E> Validator<E>.Property<String?>.containsAllIgnoringCase(vararg values: St
  *
  * @param values specifies the all values that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAllIgnoringCase(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAllIgnoringCase(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAll(values)) { it == null || values.all { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -215,9 +215,9 @@ fun <E> Validator<E>.Property<String?>.containsAllIgnoringCase(values: Iterable<
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAny(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAny(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAny(values.toSet())) { it == null || values.toSet().any { e -> it.contains(e) } }
 
 /**
@@ -225,9 +225,9 @@ fun <E> Validator<E>.Property<String?>.containsAny(vararg values: String): Valid
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAny(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAny(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAny(values)) { it == null || values.any { e -> it.contains(e) } }
 
 /**
@@ -235,9 +235,9 @@ fun <E> Validator<E>.Property<String?>.containsAny(values: Iterable<String>): Va
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAnyIgnoringCase(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAnyIgnoringCase(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAny(values.toSet())) { it == null || values.toSet().any { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -245,9 +245,9 @@ fun <E> Validator<E>.Property<String?>.containsAnyIgnoringCase(vararg values: St
  *
  * @param values specifies the values that one should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.containsAnyIgnoringCase(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.containsAnyIgnoringCase(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsAny(values)) { it == null || values.any { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -255,9 +255,9 @@ fun <E> Validator<E>.Property<String?>.containsAnyIgnoringCase(values: Iterable<
  *
  * @param value specifies the value that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContain(value: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContain(value: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContain(value)) { it == null || !it.contains(value) }
 
 /**
@@ -265,9 +265,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContain(value: String): Validator<
  *
  * @param value specifies the value that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainIgnoringCase(value: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainIgnoringCase(value: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContain(value)) { it == null || !it.contains(other = value, ignoreCase = true) }
 
 /**
@@ -275,9 +275,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainIgnoringCase(value: String)
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAll(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAll(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAll(values.toSet())) { it == null || !values.toSet().all { e -> it.contains(e) } }
 
 /**
@@ -285,9 +285,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAll(vararg values: String):
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAll(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAll(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAll(values)) { it == null || !values.all { e -> it.contains(e) } }
 
 /**
@@ -295,9 +295,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAll(values: Iterable<String
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAllIgnoringCase(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAllIgnoringCase(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAll(values.toSet())) { it == null || !values.toSet().all { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -305,9 +305,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAllIgnoringCase(vararg valu
  *
  * @param values specifies the all values that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAllIgnoringCase(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAllIgnoringCase(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAll(values)) { it == null || !values.all { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -315,9 +315,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAllIgnoringCase(values: Ite
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAny(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAny(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAny(values.toSet())) { it == null || !values.toSet().any { e -> it.contains(e) } }
 
 /**
@@ -325,9 +325,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAny(vararg values: String):
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAny(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAny(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAny(values)) { it == null || !values.any { e -> it.contains(e) } }
 
 /**
@@ -335,9 +335,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAny(values: Iterable<String
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAnyIgnoringCase(vararg values: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAnyIgnoringCase(vararg values: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAny(values.toSet())) { it == null || !values.toSet().any { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -345,9 +345,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAnyIgnoringCase(vararg valu
  *
  * @param values specifies the values that one shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContainAnyIgnoringCase(values: Iterable<String>): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContainAnyIgnoringCase(values: Iterable<String>): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainAny(values)) { it == null || !values.any { e -> it.contains(other = e, ignoreCase = true) } }
 
 /**
@@ -355,9 +355,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContainAnyIgnoringCase(values: Ite
  *
  * @param regex specifies the pattern value that should match
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.matches(regex: Regex): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.matches(regex: Regex): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Matches(regex)) { it == null || it.matches(regex) }
 
 /**
@@ -365,9 +365,9 @@ fun <E> Validator<E>.Property<String?>.matches(regex: Regex): Validator<E>.Prope
  *
  * @param regex specifies the pattern value that shouldn't match
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotMatch(regex: Regex): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotMatch(regex: Regex): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotMatch(regex)) { it == null || !it.matches(regex) }
 
 /**
@@ -375,9 +375,9 @@ fun <E> Validator<E>.Property<String?>.doesNotMatch(regex: Regex): Validator<E>.
  *
  * @param regex specifies the pattern value that should contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.contains(regex: Regex): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.contains(regex: Regex): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(ContainsRegex(regex)) { it == null || it.contains(regex) }
 
 /**
@@ -385,9 +385,9 @@ fun <E> Validator<E>.Property<String?>.contains(regex: Regex): Validator<E>.Prop
  *
  * @param regex specifies the pattern value that shouldn't contain
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotContain(regex: Regex): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotContain(regex: Regex): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotContainRegex(regex)) { it == null || !it.contains(regex) }
 
 /**
@@ -395,9 +395,9 @@ fun <E> Validator<E>.Property<String?>.doesNotContain(regex: Regex): Validator<E
  *
  * @param prefix specifies the value that should start
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.startsWith(prefix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.startsWith(prefix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(StartsWith(prefix)) { it == null || it.startsWith(prefix) }
 
 /**
@@ -405,9 +405,9 @@ fun <E> Validator<E>.Property<String?>.startsWith(prefix: String): Validator<E>.
  *
  * @param prefix specifies the value that should start
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.startsWithIgnoringCase(prefix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.startsWithIgnoringCase(prefix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(StartsWith(prefix)) { it == null || it.startsWith(prefix = prefix, ignoreCase = true) }
 
 /**
@@ -415,9 +415,9 @@ fun <E> Validator<E>.Property<String?>.startsWithIgnoringCase(prefix: String): V
  *
  * @param prefix specifies the value that shouldn't start
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotStartWith(prefix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotStartWith(prefix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotStartWith(prefix)) { it == null || !it.startsWith(prefix) }
 
 /**
@@ -425,9 +425,9 @@ fun <E> Validator<E>.Property<String?>.doesNotStartWith(prefix: String): Validat
  *
  * @param prefix specifies the value that shouldn't start
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotStartWithIgnoringCase(prefix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotStartWithIgnoringCase(prefix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotStartWith(prefix)) { it == null || !it.startsWith(prefix = prefix, ignoreCase = true) }
 
 /**
@@ -435,9 +435,9 @@ fun <E> Validator<E>.Property<String?>.doesNotStartWithIgnoringCase(prefix: Stri
  *
  * @param suffix specifies the value that should end
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.endsWith(suffix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.endsWith(suffix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(EndsWith(suffix)) { it == null || it.endsWith(suffix) }
 
 /**
@@ -445,9 +445,9 @@ fun <E> Validator<E>.Property<String?>.endsWith(suffix: String): Validator<E>.Pr
  *
  * @param suffix specifies the value that should end
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.endsWithIgnoringCase(suffix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.endsWithIgnoringCase(suffix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(EndsWith(suffix)) { it == null || it.endsWith(suffix = suffix, ignoreCase = true) }
 
 /**
@@ -455,9 +455,9 @@ fun <E> Validator<E>.Property<String?>.endsWithIgnoringCase(suffix: String): Val
  *
  * @param suffix specifies the value that shouldn't end
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotEndWith(suffix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotEndWith(suffix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotEndWith(suffix)) { it == null || !it.endsWith(suffix) }
 
 /**
@@ -465,18 +465,18 @@ fun <E> Validator<E>.Property<String?>.doesNotEndWith(suffix: String): Validator
  *
  * @param suffix specifies the value that shouldn't end
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.doesNotEndWithIgnoringCase(suffix: String): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.doesNotEndWithIgnoringCase(suffix: String): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(NotEndWith(suffix)) { it == null || !it.endsWith(suffix = suffix, ignoreCase = true) }
 
 /**
  * Validates if the [String] property value is a valid email
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isEmail(): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isEmail(): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Email) {
         it == null || it.matches(Regex(
             "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"))
@@ -486,9 +486,9 @@ fun <E> Validator<E>.Property<String?>.isEmail(): Validator<E>.Property<String?>
  * Validates if the [String] property value is a valid website
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<String?>.isWebsite(): Validator<E>.Property<String?> =
+fun <E> Validator<E>.ReceiverValidator<E, String?>.isWebsite(): Validator<E>.ReceiverValidator<E, String?> =
     this.validate(Website) {
         it == null || it.matches(Regex(
             "^(https?:\\/\\/)?([a-zA-Z0-9]+(-?[a-zA-Z0-9])*\\.)+[\\w]{2,}(\\/\\S*)?\$"))

--- a/valiktor-core/src/test/kotlin/org/valiktor/functions/BooleanFunctionsTest.kt
+++ b/valiktor-core/src/test/kotlin/org/valiktor/functions/BooleanFunctionsTest.kt
@@ -17,16 +17,10 @@
 package org.valiktor.functions
 
 import org.assertj.core.api.Assertions.assertThat
+import org.valiktor.Constraint
 import org.valiktor.ConstraintViolationException
 import org.valiktor.DefaultConstraintViolation
-import org.valiktor.constraints.Equals
-import org.valiktor.constraints.False
-import org.valiktor.constraints.In
-import org.valiktor.constraints.NotEquals
-import org.valiktor.constraints.NotIn
-import org.valiktor.constraints.NotNull
-import org.valiktor.constraints.Null
-import org.valiktor.constraints.True
+import org.valiktor.constraints.*
 import org.valiktor.functions.BooleanFunctionsFixture.Employee
 import org.valiktor.validate
 import kotlin.test.Test
@@ -34,15 +28,21 @@ import kotlin.test.assertFailsWith
 
 private object BooleanFunctionsFixture {
 
-    data class Employee(val active: Boolean? = null)
+    data class Employee(val active: Boolean? = null) {
+
+        fun isActive(): Boolean? = this.active
+    }
 }
 
 class BooleanFunctionsTest {
+
+    private val names = setOf("active", "isActive")
 
     @Test
     fun `isNull with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isNull()
+            validate(Employee::isActive).isNull()
         }
     }
 
@@ -51,16 +51,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = true)) {
                 validate(Employee::active).isNull()
+                validate(Employee::isActive).isNull()
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", value = true, constraint = Null))
+
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(true, Null))
     }
 
     @Test
     fun `isNotNull with not null value should be valid`() {
         validate(Employee(active = true)) {
             validate(Employee::active).isNotNull()
+            validate(Employee::isActive).isNotNull()
         }
     }
 
@@ -69,16 +71,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee()) {
                 validate(Employee::active).isNotNull()
+                validate(Employee::isActive).isNotNull()
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", constraint = NotNull))
+
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(null, NotNull))
     }
 
     @Test
     fun `isEqualTo with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isEqualTo(true)
+            validate(Employee::isActive).isEqualTo(true)
         }
     }
 
@@ -86,6 +90,7 @@ class BooleanFunctionsTest {
     fun `isEqualTo with same value should be valid`() {
         validate(Employee(active = true)) {
             validate(Employee::active).isEqualTo(true)
+            validate(Employee::isActive).isEqualTo(true)
         }
     }
 
@@ -94,16 +99,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = true)) {
                 validate(Employee::active).isEqualTo(false)
+                validate(Employee::isActive).isEqualTo(false)
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", value = true, constraint = Equals(false)))
+
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(true, Equals(false)))
     }
 
     @Test
     fun `isNotEqualTo with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isNotEqualTo(false)
+            validate(Employee::isActive).isNotEqualTo(false)
         }
     }
 
@@ -111,6 +118,7 @@ class BooleanFunctionsTest {
     fun `isNotEqualTo with different value should be valid`() {
         validate(Employee(active = false)) {
             validate(Employee::active).isNotEqualTo(true)
+            validate(Employee::isActive).isNotEqualTo(true)
         }
     }
 
@@ -119,16 +127,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = false)) {
                 validate(Employee::active).isNotEqualTo(false)
+                validate(Employee::isActive).isNotEqualTo(false)
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", value = false, constraint = NotEquals(false)))
+
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(false, NotEquals(false)))
     }
 
     @Test
     fun `isIn vararg with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isIn(true, false)
+            validate(Employee::isActive).isIn(true, false)
         }
     }
 
@@ -136,6 +146,7 @@ class BooleanFunctionsTest {
     fun `isIn vararg with same value should be valid`() {
         validate(Employee(active = false)) {
             validate(Employee::active).isIn(true, false)
+            validate(Employee::isActive).isIn(true, false)
         }
     }
 
@@ -144,16 +155,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = true)) {
                 validate(Employee::active).isIn(false)
+                validate(Employee::isActive).isIn(false)
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", value = true, constraint = In(setOf(false))))
+
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(true, In(setOf(false))))
     }
 
     @Test
     fun `isIn iterable with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isIn(listOf(true, false))
+            validate(Employee::isActive).isIn(listOf(true, false))
         }
     }
 
@@ -161,6 +174,7 @@ class BooleanFunctionsTest {
     fun `isIn iterable with same value should be valid`() {
         validate(Employee(active = false)) {
             validate(Employee::active).isIn(listOf(true, false))
+            validate(Employee::isActive).isIn(listOf(true, false))
         }
     }
 
@@ -169,16 +183,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = true)) {
                 validate(Employee::active).isIn(listOf(false))
+                validate(Employee::isActive).isIn(listOf(false))
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", value = true, constraint = In(listOf(false))))
+
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(true, In(listOf(false))))
     }
 
     @Test
     fun `isNotIn vararg with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isNotIn(false, true)
+            validate(Employee::isActive).isNotIn(false, true)
         }
     }
 
@@ -186,6 +202,7 @@ class BooleanFunctionsTest {
     fun `isNotIn vararg with different value should be valid`() {
         validate(Employee(active = false)) {
             validate(Employee::active).isNotIn(true)
+            validate(Employee::isActive).isNotIn(true)
         }
     }
 
@@ -194,16 +211,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = false)) {
                 validate(Employee::active).isNotIn(true, false)
+                validate(Employee::isActive).isNotIn(true, false)
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", value = false, constraint = NotIn(setOf(true, false))))
+
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(false, NotIn(setOf(true, false))))
     }
 
     @Test
     fun `isNotIn iterable with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isNotIn(listOf(false, true))
+            validate(Employee::isActive).isNotIn(listOf(false, true))
         }
     }
 
@@ -211,6 +230,7 @@ class BooleanFunctionsTest {
     fun `isNotIn iterable with different value should be valid`() {
         validate(Employee(active = false)) {
             validate(Employee::active).isNotIn(listOf(true))
+            validate(Employee::isActive).isNotIn(listOf(true))
         }
     }
 
@@ -219,16 +239,17 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = false)) {
                 validate(Employee::active).isNotIn(listOf(true, false))
+                validate(Employee::isActive).isNotIn(listOf(true, false))
             }
         }
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(property = "active", value = false, constraint = NotIn(listOf(true, false))))
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(false, NotIn(listOf(true, false))))
     }
 
     @Test
     fun `isTrue with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isTrue()
+            validate(Employee::isActive).isTrue()
         }
     }
 
@@ -236,6 +257,7 @@ class BooleanFunctionsTest {
     fun `isTrue with true should be valid`() {
         validate(Employee(active = true)) {
             validate(Employee::active).isTrue()
+            validate(Employee::isActive).isTrue()
         }
     }
 
@@ -244,20 +266,18 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = false)) {
                 validate(Employee::active).isTrue()
+                validate(Employee::isActive).isTrue()
             }
         }
 
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(
-                property = "active",
-                value = false,
-                constraint = True))
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(false, True))
     }
 
     @Test
     fun `isFalse with null value should be valid`() {
         validate(Employee()) {
             validate(Employee::active).isFalse()
+            validate(Employee::isActive).isFalse()
         }
     }
 
@@ -265,6 +285,7 @@ class BooleanFunctionsTest {
     fun `isFalse with false should be valid`() {
         validate(Employee(active = false)) {
             validate(Employee::active).isFalse()
+            validate(Employee::isActive).isFalse()
         }
     }
 
@@ -273,13 +294,17 @@ class BooleanFunctionsTest {
         val exception = assertFailsWith<ConstraintViolationException> {
             validate(Employee(active = true)) {
                 validate(Employee::active).isFalse()
+                validate(Employee::isActive).isFalse()
             }
         }
 
-        assertThat(exception.constraintViolations).containsExactly(
-            DefaultConstraintViolation(
-                property = "active",
-                value = true,
-                constraint = False))
+        assertThat(exception.constraintViolations).containsExactly(*expectedViolations(true, False))
     }
+
+    private fun expectedViolations(
+        value: Boolean?,
+        constraint: Constraint
+    ): Array<DefaultConstraintViolation> = names.map {
+        DefaultConstraintViolation(property = it, value = value, constraint = constraint)
+    }.toTypedArray()
 }

--- a/valiktor-javamoney/src/main/kotlin/org/valiktor/functions/MonetaryAmountFunctions.kt
+++ b/valiktor-javamoney/src/main/kotlin/org/valiktor/functions/MonetaryAmountFunctions.kt
@@ -43,9 +43,9 @@ import javax.money.MonetaryAmount
  *
  * @param value specifies the [Number] value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isEqualTo(value: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isEqualTo(value: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Equals(it?.factory?.setNumber(value)?.create()) },
         { it == null || it == it.factory.setNumber(value).create() })
@@ -55,9 +55,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isEqualTo(value: Number): 
  *
  * @param value specifies the [Number] value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotEqualTo(value: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNotEqualTo(value: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { NotEquals(it?.factory?.setNumber(value)?.create()) },
         { it == null || it != it.factory.setNumber(value).create() })
@@ -67,9 +67,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotEqualTo(value: Number
  *
  * @param values specifies the array of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isIn(vararg values: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isIn(vararg values: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { In(values.map { value -> it?.factory?.setNumber(value)?.create() }.toSet()) },
         { it == null || values.map { value -> it.factory.setNumber(value).create() }.contains(it) })
@@ -79,9 +79,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isIn(vararg values: Number
  *
  * @param values specifies the iterable of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isIn(values: Iterable<Number>): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isIn(values: Iterable<Number>): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { In(values.map { value -> it?.factory?.setNumber(value)?.create() }) },
         { it == null || values.map { value -> it.factory.setNumber(value).create() }.contains(it) })
@@ -91,9 +91,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isIn(values: Iterable<Numb
  *
  * @param values specifies the array of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotIn(vararg values: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNotIn(vararg values: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { NotIn(values.map { value -> it?.factory?.setNumber(value)?.create() }.toSet()) },
         { it == null || !values.map { value -> it.factory.setNumber(value).create() }.contains(it) })
@@ -103,9 +103,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotIn(vararg values: Num
  *
  * @param values specifies the iterable of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotIn(values: Iterable<Number>): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNotIn(values: Iterable<Number>): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { NotIn(values.map { value -> it?.factory?.setNumber(value)?.create() }) },
         { it == null || !values.map { value -> it.factory.setNumber(value).create() }.contains(it) })
@@ -116,9 +116,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotIn(values: Iterable<N
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isLessThan(value: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isLessThan(value: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Less(it?.factory?.setNumber(value)?.create()) },
         { it == null || it < it.factory.setNumber(value).create() })
@@ -129,9 +129,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isLessThan(value: Number):
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isLessThanOrEqualTo(value: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isLessThanOrEqualTo(value: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { LessOrEqual(it?.factory?.setNumber(value)?.create()) },
         { it == null || it <= it.factory.setNumber(value).create() })
@@ -142,9 +142,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isLessThanOrEqualTo(value:
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isGreaterThan(value: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isGreaterThan(value: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Greater(it?.factory?.setNumber(value)?.create()) },
         { it == null || it > it.factory.setNumber(value).create() })
@@ -155,9 +155,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isGreaterThan(value: Numbe
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isGreaterThanOrEqualTo(value: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isGreaterThanOrEqualTo(value: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { GreaterOrEqual(it?.factory?.setNumber(value)?.create()) },
         { it == null || it >= it.factory.setNumber(value).create() })
@@ -169,9 +169,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isGreaterThanOrEqualTo(val
  * @property end (inclusive) specifies [Number] value that should end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isBetween(start: Number, end: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isBetween(start: Number, end: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Between(it?.factory?.setNumber(start)?.create(), it?.factory?.setNumber(end)?.create()) },
         { it == null || it in it.factory.setNumber(start).create().rangeTo(it.factory.setNumber(end).create()) })
@@ -183,9 +183,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isBetween(start: Number, e
  * @property end (inclusive) specifies [Number] value that shouldn't end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotBetween(start: Number, end: Number): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNotBetween(start: Number, end: Number): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { NotBetween(it?.factory?.setNumber(start)?.create(), it?.factory?.setNumber(end)?.create()) },
         { it == null || it !in it.factory.setNumber(start).create().rangeTo(it.factory.setNumber(end).create()) })
@@ -194,9 +194,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotBetween(start: Number
  * Validates if the [MonetaryAmount] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isZero(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isZero(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Equals(it?.factory?.setNumber(ZERO)?.create()) },
         { it == null || it.isZero })
@@ -205,9 +205,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isZero(): Validator<E>.Pro
  * Validates if the [MonetaryAmount] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotZero(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNotZero(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { NotEquals(it?.factory?.setNumber(ZERO)?.create()) },
         { it == null || !it.isZero })
@@ -216,9 +216,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotZero(): Validator<E>.
  * Validates if the [MonetaryAmount] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isOne(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isOne(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Equals(it?.factory?.setNumber(ONE)?.create()) },
         { it == null || it == it.factory.setNumber(ONE).create() })
@@ -227,9 +227,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isOne(): Validator<E>.Prop
  * Validates if the [MonetaryAmount] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotOne(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNotOne(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { NotEquals(it?.factory?.setNumber(ONE)?.create()) },
         { it == null || it != it.factory.setNumber(ONE).create() })
@@ -238,9 +238,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNotOne(): Validator<E>.P
  * Validates if the [MonetaryAmount] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isPositive(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isPositive(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Greater(it?.factory?.setNumber(ZERO)?.create()) },
         { it == null || it > it.factory.setNumber(ZERO).create() })
@@ -249,9 +249,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isPositive(): Validator<E>
  * Validates if the [MonetaryAmount] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isPositiveOrZero(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { GreaterOrEqual(it?.factory?.setNumber(ZERO)?.create()) },
         { it == null || it >= it.factory.setNumber(ZERO).create() })
@@ -260,9 +260,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isPositiveOrZero(): Valida
  * Validates if the [MonetaryAmount] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNegative(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNegative(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { Less(it?.factory?.setNumber(ZERO)?.create()) },
         { it == null || it < it.factory.setNumber(ZERO).create() })
@@ -271,9 +271,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNegative(): Validator<E>
  * Validates if the [MonetaryAmount] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNegativeOrZero(): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(
         { LessOrEqual(it?.factory?.setNumber(ZERO)?.create()) },
         { it == null || it <= it.factory.setNumber(ZERO).create() })
@@ -285,9 +285,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.isNegativeOrZero(): Valida
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.number.precision - it.number.scale in min.rangeTo(max) }
 
 /**
@@ -297,9 +297,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasIntegerDigits(min: Int 
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(DecimalDigits(min, max)) { it == null || (if (it.number.scale < 0) 0 else it.number.scale) in min.rangeTo(max) }
 
 /**
@@ -307,9 +307,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasDecimalDigits(min: Int 
  *
  * @param currency specifies the currency unit to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyEqualTo(currency: CurrencyUnit): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasCurrencyEqualTo(currency: CurrencyUnit): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(CurrencyEquals(currency)) { it == null || it.currency == currency }
 
 /**
@@ -317,9 +317,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyEqualTo(currenc
  *
  * @param currency specifies the currency unit to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyNotEqualTo(currency: CurrencyUnit): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasCurrencyNotEqualTo(currency: CurrencyUnit): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(CurrencyNotEquals(currency)) { it == null || it.currency != currency }
 
 /**
@@ -327,9 +327,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyNotEqualTo(curr
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyIn(vararg currencies: CurrencyUnit): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasCurrencyIn(vararg currencies: CurrencyUnit): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(CurrencyIn(currencies.toSet())) { it == null || currencies.contains(it.currency) }
 
 /**
@@ -337,9 +337,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyIn(vararg curre
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyIn(currencies: Iterable<CurrencyUnit>): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasCurrencyIn(currencies: Iterable<CurrencyUnit>): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(CurrencyIn(currencies)) { it == null || currencies.contains(it.currency) }
 
 /**
@@ -347,9 +347,9 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyIn(currencies: 
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyNotIn(vararg currencies: CurrencyUnit): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasCurrencyNotIn(vararg currencies: CurrencyUnit): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(CurrencyNotIn(currencies.toSet())) { it == null || !currencies.contains(it.currency) }
 
 /**
@@ -357,7 +357,7 @@ fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyNotIn(vararg cu
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E, T : MonetaryAmount> Validator<E>.Property<T?>.hasCurrencyNotIn(currencies: Iterable<CurrencyUnit>): Validator<E>.Property<T?> =
+fun <E, T : MonetaryAmount> Validator<E>.ReceiverValidator<E, T?>.hasCurrencyNotIn(currencies: Iterable<CurrencyUnit>): Validator<E>.ReceiverValidator<E, T?> =
     this.validate(CurrencyNotIn(currencies)) { it == null || !currencies.contains(it.currency) }

--- a/valiktor-javatime/src/main/kotlin/org/valiktor/functions/LocalDateFunctions.kt
+++ b/valiktor-javatime/src/main/kotlin/org/valiktor/functions/LocalDateFunctions.kt
@@ -25,16 +25,16 @@ import java.time.LocalDate
  * Validates if the [LocalDate] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDate?>.isToday(): Validator<E>.Property<LocalDate?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDate?>.isToday(): Validator<E>.ReceiverValidator<E, LocalDate?> =
     this.validate(Today) { it == null || it == LocalDate.now() }
 
 /**
  * Validates if the [LocalDate] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDate?>.isNotToday(): Validator<E>.Property<LocalDate?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDate?>.isNotToday(): Validator<E>.ReceiverValidator<E, LocalDate?> =
     this.validate(NotToday) { it == null || it != LocalDate.now() }

--- a/valiktor-javatime/src/main/kotlin/org/valiktor/functions/LocalDateTimeFunctions.kt
+++ b/valiktor-javatime/src/main/kotlin/org/valiktor/functions/LocalDateTimeFunctions.kt
@@ -26,16 +26,16 @@ import java.time.LocalDateTime
  * Validates if the [LocalDateTime] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDateTime?>.isToday(): Validator<E>.Property<LocalDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDateTime?>.isToday(): Validator<E>.ReceiverValidator<E, LocalDateTime?> =
     this.validate(Today) { it == null || it.toLocalDate() == LocalDate.now() }
 
 /**
  * Validates if the [LocalDateTime] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDateTime?>.isNotToday(): Validator<E>.Property<LocalDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDateTime?>.isNotToday(): Validator<E>.ReceiverValidator<E, LocalDateTime?> =
     this.validate(NotToday) { it == null || it.toLocalDate() != LocalDate.now() }

--- a/valiktor-javatime/src/main/kotlin/org/valiktor/functions/OffsetDateTimeFunctions.kt
+++ b/valiktor-javatime/src/main/kotlin/org/valiktor/functions/OffsetDateTimeFunctions.kt
@@ -26,16 +26,16 @@ import java.time.OffsetDateTime
  * Validates if the [OffsetDateTime] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<OffsetDateTime?>.isToday(): Validator<E>.Property<OffsetDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, OffsetDateTime?>.isToday(): Validator<E>.ReceiverValidator<E, OffsetDateTime?> =
     this.validate(Today) { it == null || it.toLocalDate() == LocalDate.now(it.offset) }
 
 /**
  * Validates if the [OffsetDateTime] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<OffsetDateTime?>.isNotToday(): Validator<E>.Property<OffsetDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, OffsetDateTime?>.isNotToday(): Validator<E>.ReceiverValidator<E, OffsetDateTime?> =
     this.validate(NotToday) { it == null || it.toLocalDate() != LocalDate.now(it.offset) }

--- a/valiktor-javatime/src/main/kotlin/org/valiktor/functions/ZonedDateTimeFunctions.kt
+++ b/valiktor-javatime/src/main/kotlin/org/valiktor/functions/ZonedDateTimeFunctions.kt
@@ -26,16 +26,16 @@ import java.time.ZonedDateTime
  * Validates if the [ZonedDateTime] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<ZonedDateTime?>.isToday(): Validator<E>.Property<ZonedDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, ZonedDateTime?>.isToday(): Validator<E>.ReceiverValidator<E, ZonedDateTime?> =
     this.validate(Today) { it == null || it.toLocalDate() == LocalDate.now(it.zone) }
 
 /**
  * Validates if the [ZonedDateTime] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<ZonedDateTime?>.isNotToday(): Validator<E>.Property<ZonedDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, ZonedDateTime?>.isNotToday(): Validator<E>.ReceiverValidator<E, ZonedDateTime?> =
     this.validate(NotToday) { it == null || it.toLocalDate() != LocalDate.now(it.zone) }

--- a/valiktor-jodamoney/src/main/kotlin/org/valiktor/functions/BigMoneyFunctions.kt
+++ b/valiktor-jodamoney/src/main/kotlin/org/valiktor/functions/BigMoneyFunctions.kt
@@ -45,9 +45,9 @@ import java.math.BigDecimal.ZERO
  *
  * @param value specifies the [BigMoney] value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isEqualTo(value: BigMoney): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isEqualTo(value: BigMoney): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(Equals(value)) { it == null || it.safelyEquals(value) }
 
 /**
@@ -55,9 +55,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isEqualTo(value: BigMoney): Validator<E
  *
  * @param value specifies the [Number] value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isEqualTo(value: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isEqualTo(value: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Equals(BigMoney.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it.compareTo(BigMoney.of(it.currencyUnit, value.asBigDecimal())) == 0 })
@@ -67,9 +67,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isEqualTo(value: Number): Validator<E>.
  *
  * @param value specifies the [BigMoney] value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotEqualTo(value: BigMoney): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotEqualTo(value: BigMoney): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(NotEquals(value)) { it == null || !it.safelyEquals(value) }
 
 /**
@@ -77,9 +77,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotEqualTo(value: BigMoney): Validato
  *
  * @param value specifies the [Number] value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotEqualTo(value: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotEqualTo(value: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { NotEquals(BigMoney.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it.compareTo(BigMoney.of(it.currencyUnit, value.asBigDecimal())) != 0 })
@@ -89,9 +89,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotEqualTo(value: Number): Validator<
  *
  * @param values specifies the array of [BigMoney] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isIn(vararg values: BigMoney): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isIn(vararg values: BigMoney): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(In(values.toSet())) { it == null || values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -99,9 +99,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isIn(vararg values: BigMoney): Validato
  *
  * @param values specifies the array of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isIn(vararg values: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isIn(vararg values: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { In(values.map { value -> BigMoney.of(it?.currencyUnit, value.asBigDecimal()) }.toSet()) },
         { it == null || values.map { value -> BigMoney.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -111,9 +111,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isIn(vararg values: Number): Validator<
  *
  * @param values specifies the iterable of [BigMoney] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isIn(values: Iterable<BigMoney>): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isIn(values: Iterable<BigMoney>): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(In(values)) { it == null || values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -121,10 +121,10 @@ fun <E> Validator<E>.Property<BigMoney?>.isIn(values: Iterable<BigMoney>): Valid
  *
  * @param values specifies the iterable of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("isInNumber")
-fun <E> Validator<E>.Property<BigMoney?>.isIn(values: Iterable<Number>): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isIn(values: Iterable<Number>): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { In(values.map { value -> BigMoney.of(it?.currencyUnit, value.asBigDecimal()) }) },
         { it == null || values.map { value -> BigMoney.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -134,9 +134,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isIn(values: Iterable<Number>): Validat
  *
  * @param values specifies the array of [BigMoney] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotIn(vararg values: BigMoney): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotIn(vararg values: BigMoney): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(NotIn(values.toSet())) { it == null || !values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -144,9 +144,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotIn(vararg values: BigMoney): Valid
  *
  * @param values specifies the array of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotIn(vararg values: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotIn(vararg values: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { NotIn(values.map { value -> BigMoney.of(it?.currencyUnit, value.asBigDecimal()) }.toSet()) },
         { it == null || !values.map { value -> BigMoney.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -156,9 +156,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotIn(vararg values: Number): Validat
  *
  * @param values specifies the iterable of [BigMoney] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotIn(values: Iterable<BigMoney>): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotIn(values: Iterable<BigMoney>): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(NotIn(values)) { it == null || !values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -166,10 +166,10 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotIn(values: Iterable<BigMoney>): Va
  *
  * @param values specifies the iterable of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("isNotInNumber")
-fun <E> Validator<E>.Property<BigMoney?>.isNotIn(values: Iterable<Number>): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotIn(values: Iterable<Number>): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { NotIn(values.map { value -> BigMoney.of(it?.currencyUnit, value.asBigDecimal()) }) },
         { it == null || !values.map { value -> BigMoney.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -180,9 +180,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotIn(values: Iterable<Number>): Vali
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isLessThan(value: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isLessThan(value: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Less(BigMoney.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it < BigMoney.of(it.currencyUnit, value.asBigDecimal()) })
@@ -193,9 +193,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isLessThan(value: Number): Validator<E>
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isLessThanOrEqualTo(value: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isLessThanOrEqualTo(value: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { LessOrEqual(BigMoney.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it <= BigMoney.of(it.currencyUnit, value.asBigDecimal()) })
@@ -206,9 +206,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isLessThanOrEqualTo(value: Number): Val
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isGreaterThan(value: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isGreaterThan(value: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Greater(BigMoney.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it > BigMoney.of(it.currencyUnit, value.asBigDecimal()) })
@@ -219,9 +219,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isGreaterThan(value: Number): Validator
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isGreaterThanOrEqualTo(value: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isGreaterThanOrEqualTo(value: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { GreaterOrEqual(BigMoney.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it >= BigMoney.of(it.currencyUnit, value.asBigDecimal()) })
@@ -233,9 +233,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isGreaterThanOrEqualTo(value: Number): 
  * @property end (inclusive) specifies [Number] value that should end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isBetween(start: Number, end: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isBetween(start: Number, end: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Between(BigMoney.of(it?.currencyUnit, start.asBigDecimal()), BigMoney.of(it?.currencyUnit, end.asBigDecimal())) },
         { it == null || it in BigMoney.of(it.currencyUnit, start.asBigDecimal()).rangeTo(BigMoney.of(it.currencyUnit, end.asBigDecimal())) })
@@ -247,9 +247,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isBetween(start: Number, end: Number): 
  * @property end (inclusive) specifies [Number] value that shouldn't end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotBetween(start: Number, end: Number): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotBetween(start: Number, end: Number): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { NotBetween(BigMoney.of(it?.currencyUnit, start.asBigDecimal()), BigMoney.of(it?.currencyUnit, end.asBigDecimal())) },
         { it == null || it !in BigMoney.of(it.currencyUnit, start.asBigDecimal()).rangeTo(BigMoney.of(it.currencyUnit, end.asBigDecimal())) })
@@ -258,9 +258,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotBetween(start: Number, end: Number
  * Validates if the [BigMoney] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isZero(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isZero(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Equals(BigMoney.of(it?.currencyUnit, ZERO)) },
         { it == null || it.isZero })
@@ -269,9 +269,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isZero(): Validator<E>.Property<BigMone
  * Validates if the [BigMoney] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotZero(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotZero(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { NotEquals(BigMoney.of(it?.currencyUnit, ZERO)) },
         { it == null || !it.isZero })
@@ -280,9 +280,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotZero(): Validator<E>.Property<BigM
  * Validates if the [BigMoney] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isOne(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isOne(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Equals(BigMoney.of(it?.currencyUnit, ONE)) },
         { it == null || it.compareTo(BigMoney.of(it.currencyUnit, ONE)) == 0 })
@@ -291,9 +291,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isOne(): Validator<E>.Property<BigMoney
  * Validates if the [BigMoney] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNotOne(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNotOne(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { NotEquals(BigMoney.of(it?.currencyUnit, ONE)) },
         { it == null || it.compareTo(BigMoney.of(it.currencyUnit, ONE)) != 0 })
@@ -302,9 +302,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNotOne(): Validator<E>.Property<BigMo
  * Validates if the [BigMoney] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isPositive(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isPositive(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Greater(BigMoney.of(it?.currencyUnit, ZERO)) },
         { it == null || it > BigMoney.of(it.currencyUnit, ZERO) })
@@ -313,9 +313,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isPositive(): Validator<E>.Property<Big
  * Validates if the [BigMoney] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isPositiveOrZero(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { GreaterOrEqual(BigMoney.of(it?.currencyUnit, ZERO)) },
         { it == null || it >= BigMoney.of(it.currencyUnit, ZERO) })
@@ -324,9 +324,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isPositiveOrZero(): Validator<E>.Proper
  * Validates if the [BigMoney] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNegative(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNegative(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { Less(BigMoney.of(it?.currencyUnit, ZERO)) },
         { it == null || it < BigMoney.of(it.currencyUnit, ZERO) })
@@ -335,9 +335,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNegative(): Validator<E>.Property<Big
  * Validates if the [BigMoney] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.isNegativeOrZero(): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(
         { LessOrEqual(BigMoney.of(it?.currencyUnit, ZERO)) },
         { it == null || it <= BigMoney.of(it.currencyUnit, ZERO) })
@@ -349,9 +349,9 @@ fun <E> Validator<E>.Property<BigMoney?>.isNegativeOrZero(): Validator<E>.Proper
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.amount.precision() - it.amount.scale() in min.rangeTo(max) }
 
 /**
@@ -361,9 +361,9 @@ fun <E> Validator<E>.Property<BigMoney?>.hasIntegerDigits(min: Int = Int.MIN_VAL
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(DecimalDigits(min, max)) { it == null || (if (it.amount.scale() < 0) 0 else it.amount.scale()) in min.rangeTo(max) }
 
 /**
@@ -371,9 +371,9 @@ fun <E> Validator<E>.Property<BigMoney?>.hasDecimalDigits(min: Int = Int.MIN_VAL
  *
  * @param currency specifies the currency unit to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyEqualTo(currency: CurrencyUnit): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasCurrencyEqualTo(currency: CurrencyUnit): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(CurrencyEquals(currency)) { it == null || it.currencyUnit == currency }
 
 /**
@@ -381,9 +381,9 @@ fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyEqualTo(currency: CurrencyUn
  *
  * @param currency specifies the currency unit to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyNotEqualTo(currency: CurrencyUnit): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasCurrencyNotEqualTo(currency: CurrencyUnit): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(CurrencyNotEquals(currency)) { it == null || it.currencyUnit != currency }
 
 /**
@@ -391,9 +391,9 @@ fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyNotEqualTo(currency: Currenc
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyIn(vararg currencies: CurrencyUnit): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasCurrencyIn(vararg currencies: CurrencyUnit): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(CurrencyIn(currencies.toSet())) { it == null || currencies.contains(it.currencyUnit) }
 
 /**
@@ -401,9 +401,9 @@ fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyIn(vararg currencies: Curren
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyIn(currencies: Iterable<CurrencyUnit>): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasCurrencyIn(currencies: Iterable<CurrencyUnit>): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(CurrencyIn(currencies)) { it == null || currencies.contains(it.currencyUnit) }
 
 /**
@@ -411,9 +411,9 @@ fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyIn(currencies: Iterable<Curr
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyNotIn(vararg currencies: CurrencyUnit): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasCurrencyNotIn(vararg currencies: CurrencyUnit): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(CurrencyNotIn(currencies.toSet())) { it == null || !currencies.contains(it.currencyUnit) }
 
 /**
@@ -421,7 +421,7 @@ fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyNotIn(vararg currencies: Cur
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<BigMoney?>.hasCurrencyNotIn(currencies: Iterable<CurrencyUnit>): Validator<E>.Property<BigMoney?> =
+fun <E> Validator<E>.ReceiverValidator<E, BigMoney?>.hasCurrencyNotIn(currencies: Iterable<CurrencyUnit>): Validator<E>.ReceiverValidator<E, BigMoney?> =
     this.validate(CurrencyNotIn(currencies)) { it == null || !currencies.contains(it.currencyUnit) }

--- a/valiktor-jodamoney/src/main/kotlin/org/valiktor/functions/MoneyFunctions.kt
+++ b/valiktor-jodamoney/src/main/kotlin/org/valiktor/functions/MoneyFunctions.kt
@@ -45,9 +45,9 @@ import java.math.BigDecimal.ZERO
  *
  * @param value specifies the [Money] value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isEqualTo(value: Money): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isEqualTo(value: Money): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(Equals(value)) { it == null || it.safelyEquals(value) }
 
 /**
@@ -55,9 +55,9 @@ fun <E> Validator<E>.Property<Money?>.isEqualTo(value: Money): Validator<E>.Prop
  *
  * @param value specifies the [Number] value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isEqualTo(value: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isEqualTo(value: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Equals(Money.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it.compareTo(Money.of(it.currencyUnit, value.asBigDecimal())) == 0 })
@@ -67,9 +67,9 @@ fun <E> Validator<E>.Property<Money?>.isEqualTo(value: Number): Validator<E>.Pro
  *
  * @param value specifies the [Money] value that should be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotEqualTo(value: Money): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotEqualTo(value: Money): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(NotEquals(value)) { it == null || !it.safelyEquals(value) }
 
 /**
@@ -77,9 +77,9 @@ fun <E> Validator<E>.Property<Money?>.isNotEqualTo(value: Money): Validator<E>.P
  *
  * @param value specifies the [Number] value that should not be equal
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotEqualTo(value: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotEqualTo(value: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { NotEquals(Money.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it.compareTo(Money.of(it.currencyUnit, value.asBigDecimal())) != 0 })
@@ -89,9 +89,9 @@ fun <E> Validator<E>.Property<Money?>.isNotEqualTo(value: Number): Validator<E>.
  *
  * @param values specifies the array of [Money] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isIn(vararg values: Money): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isIn(vararg values: Money): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(In(values.toSet())) { it == null || values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -99,9 +99,9 @@ fun <E> Validator<E>.Property<Money?>.isIn(vararg values: Money): Validator<E>.P
  *
  * @param values specifies the array of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isIn(vararg values: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isIn(vararg values: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { In(values.map { value -> Money.of(it?.currencyUnit, value.asBigDecimal()) }.toSet()) },
         { it == null || values.map { value -> Money.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -111,9 +111,9 @@ fun <E> Validator<E>.Property<Money?>.isIn(vararg values: Number): Validator<E>.
  *
  * @param values specifies the iterable of [Money] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isIn(values: Iterable<Money>): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isIn(values: Iterable<Money>): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(In(values)) { it == null || values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -121,10 +121,10 @@ fun <E> Validator<E>.Property<Money?>.isIn(values: Iterable<Money>): Validator<E
  *
  * @param values specifies the iterable of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("isInNumber")
-fun <E> Validator<E>.Property<Money?>.isIn(values: Iterable<Number>): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isIn(values: Iterable<Number>): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { In(values.map { value -> Money.of(it?.currencyUnit, value.asBigDecimal()) }) },
         { it == null || values.map { value -> Money.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -134,9 +134,9 @@ fun <E> Validator<E>.Property<Money?>.isIn(values: Iterable<Number>): Validator<
  *
  * @param values specifies the array of [Money] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotIn(vararg values: Money): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotIn(vararg values: Money): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(NotIn(values.toSet())) { it == null || !values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -144,9 +144,9 @@ fun <E> Validator<E>.Property<Money?>.isNotIn(vararg values: Money): Validator<E
  *
  * @param values specifies the array of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotIn(vararg values: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotIn(vararg values: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { NotIn(values.map { value -> Money.of(it?.currencyUnit, value.asBigDecimal()) }.toSet()) },
         { it == null || !values.map { value -> Money.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -156,9 +156,9 @@ fun <E> Validator<E>.Property<Money?>.isNotIn(vararg values: Number): Validator<
  *
  * @param values specifies the iterable of [Money] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotIn(values: Iterable<Money>): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotIn(values: Iterable<Money>): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(NotIn(values)) { it == null || !values.any { e -> it.safelyEquals(e) } }
 
 /**
@@ -166,10 +166,10 @@ fun <E> Validator<E>.Property<Money?>.isNotIn(values: Iterable<Money>): Validato
  *
  * @param values specifies the iterable of [Number] values to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
 @JvmName("isNotInNumber")
-fun <E> Validator<E>.Property<Money?>.isNotIn(values: Iterable<Number>): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotIn(values: Iterable<Number>): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { NotIn(values.map { value -> Money.of(it?.currencyUnit, value.asBigDecimal()) }) },
         { it == null || !values.map { value -> Money.of(it.currencyUnit, value.asBigDecimal()) }.any { e -> it.compareTo(e) == 0 } })
@@ -180,9 +180,9 @@ fun <E> Validator<E>.Property<Money?>.isNotIn(values: Iterable<Number>): Validat
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isLessThan(value: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isLessThan(value: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Less(Money.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it < Money.of(it.currencyUnit, value.asBigDecimal()) })
@@ -193,9 +193,9 @@ fun <E> Validator<E>.Property<Money?>.isLessThan(value: Number): Validator<E>.Pr
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isLessThanOrEqualTo(value: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isLessThanOrEqualTo(value: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { LessOrEqual(Money.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it <= Money.of(it.currencyUnit, value.asBigDecimal()) })
@@ -206,9 +206,9 @@ fun <E> Validator<E>.Property<Money?>.isLessThanOrEqualTo(value: Number): Valida
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isGreaterThan(value: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isGreaterThan(value: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Greater(Money.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it > Money.of(it.currencyUnit, value.asBigDecimal()) })
@@ -219,9 +219,9 @@ fun <E> Validator<E>.Property<Money?>.isGreaterThan(value: Number): Validator<E>
  * @property value specifies the [Number] value that should be validated
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isGreaterThanOrEqualTo(value: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isGreaterThanOrEqualTo(value: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { GreaterOrEqual(Money.of(it?.currencyUnit, value.asBigDecimal())) },
         { it == null || it >= Money.of(it.currencyUnit, value.asBigDecimal()) })
@@ -233,9 +233,9 @@ fun <E> Validator<E>.Property<Money?>.isGreaterThanOrEqualTo(value: Number): Val
  * @property end (inclusive) specifies [Number] value that should end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isBetween(start: Number, end: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isBetween(start: Number, end: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Between(Money.of(it?.currencyUnit, start.asBigDecimal()), Money.of(it?.currencyUnit, end.asBigDecimal())) },
         { it == null || it in Money.of(it.currencyUnit, start.asBigDecimal()).rangeTo(Money.of(it.currencyUnit, end.asBigDecimal())) })
@@ -247,9 +247,9 @@ fun <E> Validator<E>.Property<Money?>.isBetween(start: Number, end: Number): Val
  * @property end (inclusive) specifies [Number] value that shouldn't end
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotBetween(start: Number, end: Number): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotBetween(start: Number, end: Number): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { NotBetween(Money.of(it?.currencyUnit, start.asBigDecimal()), Money.of(it?.currencyUnit, end.asBigDecimal())) },
         { it == null || it !in Money.of(it.currencyUnit, start.asBigDecimal()).rangeTo(Money.of(it.currencyUnit, end.asBigDecimal())) })
@@ -258,9 +258,9 @@ fun <E> Validator<E>.Property<Money?>.isNotBetween(start: Number, end: Number): 
  * Validates if the [Money] property is equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isZero(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isZero(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Equals(Money.of(it?.currencyUnit, ZERO)) },
         { it == null || it.isZero })
@@ -269,9 +269,9 @@ fun <E> Validator<E>.Property<Money?>.isZero(): Validator<E>.Property<Money?> =
  * Validates if the [Money] property is not equal to zero
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotZero(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotZero(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { NotEquals(Money.of(it?.currencyUnit, ZERO)) },
         { it == null || !it.isZero })
@@ -280,9 +280,9 @@ fun <E> Validator<E>.Property<Money?>.isNotZero(): Validator<E>.Property<Money?>
  * Validates if the [Money] property is equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isOne(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isOne(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Equals(Money.of(it?.currencyUnit, ONE)) },
         { it == null || it.compareTo(Money.of(it.currencyUnit, ONE)) == 0 })
@@ -291,9 +291,9 @@ fun <E> Validator<E>.Property<Money?>.isOne(): Validator<E>.Property<Money?> =
  * Validates if the [Money] property is not equal to one
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNotOne(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNotOne(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { NotEquals(Money.of(it?.currencyUnit, ONE)) },
         { it == null || it.compareTo(Money.of(it.currencyUnit, ONE)) != 0 })
@@ -302,9 +302,9 @@ fun <E> Validator<E>.Property<Money?>.isNotOne(): Validator<E>.Property<Money?> 
  * Validates if the [Money] property is positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isPositive(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isPositive(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Greater(Money.of(it?.currencyUnit, ZERO)) },
         { it == null || it > Money.of(it.currencyUnit, ZERO) })
@@ -313,9 +313,9 @@ fun <E> Validator<E>.Property<Money?>.isPositive(): Validator<E>.Property<Money?
  * Validates if the [Money] property isn't negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isPositiveOrZero(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isPositiveOrZero(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { GreaterOrEqual(Money.of(it?.currencyUnit, ZERO)) },
         { it == null || it >= Money.of(it.currencyUnit, ZERO) })
@@ -324,9 +324,9 @@ fun <E> Validator<E>.Property<Money?>.isPositiveOrZero(): Validator<E>.Property<
  * Validates if the [Money] property is negative
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNegative(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNegative(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { Less(Money.of(it?.currencyUnit, ZERO)) },
         { it == null || it < Money.of(it.currencyUnit, ZERO) })
@@ -335,9 +335,9 @@ fun <E> Validator<E>.Property<Money?>.isNegative(): Validator<E>.Property<Money?
  * Validates if the [Money] property isn't positive
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.isNegativeOrZero(): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.isNegativeOrZero(): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(
         { LessOrEqual(Money.of(it?.currencyUnit, ZERO)) },
         { it == null || it <= Money.of(it.currencyUnit, ZERO) })
@@ -349,9 +349,9 @@ fun <E> Validator<E>.Property<Money?>.isNegativeOrZero(): Validator<E>.Property<
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasIntegerDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(IntegerDigits(min, max)) { it == null || it.amount.precision() - it.amount.scale() in min.rangeTo(max) }
 
 /**
@@ -361,9 +361,9 @@ fun <E> Validator<E>.Property<Money?>.hasIntegerDigits(min: Int = Int.MIN_VALUE,
  * @property max specifies the maximum size
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasDecimalDigits(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(DecimalDigits(min, max)) { it == null || (if (it.amount.scale() < 0) 0 else it.amount.scale()) in min.rangeTo(max) }
 
 /**
@@ -371,9 +371,9 @@ fun <E> Validator<E>.Property<Money?>.hasDecimalDigits(min: Int = Int.MIN_VALUE,
  *
  * @param currency specifies the currency unit to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasCurrencyEqualTo(currency: CurrencyUnit): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasCurrencyEqualTo(currency: CurrencyUnit): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(CurrencyEquals(currency)) { it == null || it.currencyUnit == currency }
 
 /**
@@ -381,9 +381,9 @@ fun <E> Validator<E>.Property<Money?>.hasCurrencyEqualTo(currency: CurrencyUnit)
  *
  * @param currency specifies the currency unit to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasCurrencyNotEqualTo(currency: CurrencyUnit): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasCurrencyNotEqualTo(currency: CurrencyUnit): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(CurrencyNotEquals(currency)) { it == null || it.currencyUnit != currency }
 
 /**
@@ -391,9 +391,9 @@ fun <E> Validator<E>.Property<Money?>.hasCurrencyNotEqualTo(currency: CurrencyUn
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasCurrencyIn(vararg currencies: CurrencyUnit): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasCurrencyIn(vararg currencies: CurrencyUnit): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(CurrencyIn(currencies.toSet())) { it == null || currencies.contains(it.currencyUnit) }
 
 /**
@@ -401,9 +401,9 @@ fun <E> Validator<E>.Property<Money?>.hasCurrencyIn(vararg currencies: CurrencyU
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasCurrencyIn(currencies: Iterable<CurrencyUnit>): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasCurrencyIn(currencies: Iterable<CurrencyUnit>): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(CurrencyIn(currencies)) { it == null || currencies.contains(it.currencyUnit) }
 
 /**
@@ -411,9 +411,9 @@ fun <E> Validator<E>.Property<Money?>.hasCurrencyIn(currencies: Iterable<Currenc
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasCurrencyNotIn(vararg currencies: CurrencyUnit): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasCurrencyNotIn(vararg currencies: CurrencyUnit): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(CurrencyNotIn(currencies.toSet())) { it == null || !currencies.contains(it.currencyUnit) }
 
 /**
@@ -421,7 +421,7 @@ fun <E> Validator<E>.Property<Money?>.hasCurrencyNotIn(vararg currencies: Curren
  *
  * @param currencies specifies the currencies to be compared
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<Money?>.hasCurrencyNotIn(currencies: Iterable<CurrencyUnit>): Validator<E>.Property<Money?> =
+fun <E> Validator<E>.ReceiverValidator<E, Money?>.hasCurrencyNotIn(currencies: Iterable<CurrencyUnit>): Validator<E>.ReceiverValidator<E, Money?> =
     this.validate(CurrencyNotIn(currencies)) { it == null || !currencies.contains(it.currencyUnit) }

--- a/valiktor-jodatime/src/main/kotlin/org/valiktor/functions/DateTimeFunctions.kt
+++ b/valiktor-jodatime/src/main/kotlin/org/valiktor/functions/DateTimeFunctions.kt
@@ -26,16 +26,16 @@ import org.valiktor.constraints.Today
  * Validates if the [DateTime] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<DateTime?>.isToday(): Validator<E>.Property<DateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, DateTime?>.isToday(): Validator<E>.ReceiverValidator<E, DateTime?> =
     this.validate(Today) { it == null || it.toLocalDate() == LocalDate.now(it.zone) }
 
 /**
  * Validates if the [DateTime] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<DateTime?>.isNotToday(): Validator<E>.Property<DateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, DateTime?>.isNotToday(): Validator<E>.ReceiverValidator<E, DateTime?> =
     this.validate(NotToday) { it == null || it.toLocalDate() != LocalDate.now(it.zone) }

--- a/valiktor-jodatime/src/main/kotlin/org/valiktor/functions/LocalDateFunctions.kt
+++ b/valiktor-jodatime/src/main/kotlin/org/valiktor/functions/LocalDateFunctions.kt
@@ -25,16 +25,16 @@ import org.valiktor.constraints.Today
  * Validates if the [LocalDate] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDate?>.isToday(): Validator<E>.Property<LocalDate?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDate?>.isToday(): Validator<E>.ReceiverValidator<E, LocalDate?> =
     this.validate(Today) { it == null || it == LocalDate.now() }
 
 /**
  * Validates if the [LocalDate] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDate?>.isNotToday(): Validator<E>.Property<LocalDate?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDate?>.isNotToday(): Validator<E>.ReceiverValidator<E, LocalDate?> =
     this.validate(NotToday) { it == null || it != LocalDate.now() }

--- a/valiktor-jodatime/src/main/kotlin/org/valiktor/functions/LocalDateTimeFunctions.kt
+++ b/valiktor-jodatime/src/main/kotlin/org/valiktor/functions/LocalDateTimeFunctions.kt
@@ -26,16 +26,16 @@ import org.valiktor.constraints.Today
  * Validates if the [LocalDateTime] property is today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDateTime?>.isToday(): Validator<E>.Property<LocalDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDateTime?>.isToday(): Validator<E>.ReceiverValidator<E, LocalDateTime?> =
     this.validate(Today) { it == null || it.toLocalDate() == LocalDate.now() }
 
 /**
  * Validates if the [LocalDateTime] property isn't today
  *
  * @receiver the property to be validated
- * @return the same receiver property
+ * @return the same receiver validator
  */
-fun <E> Validator<E>.Property<LocalDateTime?>.isNotToday(): Validator<E>.Property<LocalDateTime?> =
+fun <E> Validator<E>.ReceiverValidator<E, LocalDateTime?>.isNotToday(): Validator<E>.ReceiverValidator<E, LocalDateTime?> =
     this.validate(NotToday) { it == null || it.toLocalDate() != LocalDate.now() }


### PR DESCRIPTION
Fixes #50 

## Proposed Changes

  - Added "ReceiverValidator" parent class which can be implemented for any type to be validated.
  - Added concrete implementation of "ReceiverValidator" for "KFunction".
  - Adapted "Property" so that it extends "ReceiverValidator".
  - Adapted all the extension functions to use the generic "ReceiverValidator" type instead of "Property".

## Draft

This Pull Request is a draft because I have not adapted the tests, yet. Please let me know if you like my approach and would consider merging it into the upstream. If so, I will adapt the tests so that each relevant test tests both `KProperty` and `KFunction`.

Also, I don't have any strong opinions on the naming, so feel free to suggest a better name than "ReceiverValidator" for the base class.