### PR TITLE
Use different E-Mail regex

### DIFF
--- a/valiktor-core/src/main/kotlin/org/valiktor/functions/StringFunctions.kt
+++ b/valiktor-core/src/main/kotlin/org/valiktor/functions/StringFunctions.kt
@@ -479,7 +479,8 @@ fun <E> Validator<E>.Property<String?>.doesNotEndWithIgnoringCase(suffix: String
 fun <E> Validator<E>.Property<String?>.isEmail(): Validator<E>.Property<String?> =
     this.validate(Email) {
         it == null || it.matches(
-            Regex("^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$")
+            // see https://emailregex.com/
+            Regex("""(?:[a-z0-9!#${'$'}%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#${'$'}%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""")
         )
     }
 

--- a/valiktor-core/src/test/kotlin/org/valiktor/functions/StringFunctionsTest.kt
+++ b/valiktor-core/src/test/kotlin/org/valiktor/functions/StringFunctionsTest.kt
@@ -1517,7 +1517,8 @@ class StringFunctionsTest {
             "test_test@test.com",
             "test-test@test.com",
             "test@test.com",
-            "test@test.test"
+            "test@test.test",
+            "test.test+test@gmail.com"
         ).forEach {
             validate(Employee(email = it)) {
                 validate(Employee::email).isEmail()


### PR DESCRIPTION
As noted in #57, the current Regex is broken for Emails like:

```
foo.bar+mysuffix@gmail.com
```

Therefore, exchange the used regex with the one from emailregex.com.